### PR TITLE
nk3: Remove update.nitrokey.com reference

### DIFF
--- a/nitrokey3/shared/main.rst
+++ b/nitrokey3/shared/main.rst
@@ -20,12 +20,7 @@ The Nitrokey 3 can be used with any current browser.
 
 .. important::
 
-   The Nitrokey App can not be used for the Nitrokey FIDO2.
-
-.. tip::
-
-   `Check online <https://update.nitrokey.com/>`__ if your Nitrokey
-   FIDO2 has the latest firmware installed.
+   The Nitrokey App can not be used for the Nitrokey 3.
 
 Passwordless authentication
 ---------------------------


### PR DESCRIPTION
update.nitrokey.com does not yet support the Nitrokey 3, so we should
not mention it in the documentation.