### PR TITLE
Change the minimum required Python version to 3.9

### DIFF
--- a/software/nitropy/all-platforms/installation.rst
+++ b/software/nitropy/all-platforms/installation.rst
@@ -12,7 +12,7 @@ This guide explains how to install nitropy with `pipx <https://pypa.github.io/pi
 Preparation
 -----------
 
-Python 3.6 or newer 
+Python 3.9 or newer 
 ~~~~~~~~~~~~~~~~~~~
   Python is already installed on most macOS and Linux systems or can be downloaded from `python.org <https://python.org>`_. See the `Downloading Python Guide <https://wiki.python.org/moin/BeginnersGuide/Download>`_ for more information.
 


### PR DESCRIPTION
Update the minimum Python version for nitropy to 3.9, according to nitrokey/pynitrokey#238.