### PR TITLE
Add Python venv directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ __preview
 
 # rst backup files
 *.rst~
+
+# Python virtual environment
+venv


### PR DESCRIPTION
Adds the Python `venv` directory to the `.gitignore` file.