### PR TITLE
NetHSM improve documentation and fix syntax errors

### DIFF
--- a/nethsm/administration.rst
+++ b/nethsm/administration.rst
@@ -981,6 +981,41 @@ A user account can be deleted as follows.
    .. tab:: REST API
       Information about the `/users/{UserID}` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/DELETE_users-UserID>`__.
 
+List Users
+~~~~~~~~~
+
+List the users on the NetHSM.
+
+The list can be retrieved as follows.
+
+.. tabs::
+   .. tab:: nitropy
+      **Optional Options**
+
+      +---------------------------------+------------------------------------------+
+      | Option                          | Description                              |
+      +=================================+==========================================+
+      | ``--details``, ``--no-details`` | Query the real name and role of the user |
+      +---------------------------------+------------------------------------------+
+
+      **Example**
+
+      .. code-block:: bash
+
+         $ nitropy nethsm --host $NETHSM_HOST list-users
+
+      .. code-block::
+
+         Users on NetHSM localhost:8843:
+
+         User ID	Real name	Role         
+         -------	---------	-------------
+         admin  	admin    	Administrator
+   .. tab:: REST API
+      Information about the `/users` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/GET_users>`__.
+
+      Information about the `/users/{UserID}` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/GET_users-UserID>`__.
+
 User Passphrase
 ~~~~~~~~~~~~~~~
 

--- a/nethsm/administration.rst
+++ b/nethsm/administration.rst
@@ -937,13 +937,13 @@ A user account can be added as follows.
 
       .. code-block:: bash
 
-         $ nitropy nethsm --host $NETHSM_HOST  add-user --real-name "Jane User" --role Operator
+         $ nitropy nethsm --host $NETHSM_HOST  add-user --real-name "Nitrokey Operator" --role Operator --user-id operator1
 
       .. code-block::
 
          Passphrase: 
          Repeat for confirmation:
-         User e8836f4cf2c7fa968bf0 added to NetHSM localhost:8443
+         User operator1 added to NetHSM localhost:8443
    .. tab:: REST API
       Information about the `/users` endpoint, to create a user without specifying the user ID, can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/POST_users>`__.
 
@@ -973,11 +973,11 @@ A user account can be deleted as follows.
 
       .. code-block:: bash
 
-         $ nitropy nethsm --host $NETHSM_HOST delete-user "Jane User"
+         $ nitropy nethsm --host $NETHSM_HOST delete-user operator1
 
       .. code-block::
 
-         User e8836f4cf2c7fa968bf0 deleted on NetHSM localhost:8443
+         User operator1 deleted on NetHSM localhost:8443
    .. tab:: REST API
       Information about the `/users/{UserID}` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/DELETE_users-UserID>`__.
 
@@ -1008,9 +1008,10 @@ The list can be retrieved as follows.
 
          Users on NetHSM localhost:8843:
 
-         User ID	Real name	Role         
-         -------	---------	-------------
-         admin  	admin    	Administrator
+         User ID  	Real name        	Role
+         ---------	-----------------	-------------
+         operator1	Nitrokey Operator	Operator
+         admin    	admin            	Administrator
    .. tab:: REST API
       Information about the `/users` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/GET_users>`__.
 
@@ -1043,13 +1044,13 @@ The user passphrase can be set as follows.
 
       .. code-block:: bash
 
-         $ nitropy nethsm --host $NETHSM_HOST set-passphrase --user-id e8836f4cf2c7fa968bf0
+         $ nitropy nethsm --host $NETHSM_HOST set-passphrase --user-id operator1
       
       .. code-block::
 
          Passphrase:
          Repeat for confirmation:
-         Updated the passphrase for user e8836f4cf2c7fa968bf0 on NetHSM localhost:8443
+         Updated the passphrase for user operator1 on NetHSM localhost:8443
    .. tab:: REST API
       Information about the `/users/{UserID}/passphrase` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/POST_users-UserID-passphrase>`__.
 
@@ -1081,11 +1082,11 @@ The *Tag* can be added as follows.
 
       .. code-block:: bash
 
-         nitropy nethsm --host $NETHSM_HOST add-operator-tag e8836f4cf2c7fa968bf0 berlin
+         nitropy nethsm --host $NETHSM_HOST add-operator-tag operator1 berlin
 
       .. code-block::
 
-         Added tag berlin for user 5d0d171c067e1f519b33 on the NetHSM localhost:8443
+         Added tag berlin for user operator1 on the NetHSM localhost:8443
    .. tab:: REST API
       Information about the `/users/{UserID}/tags/{Tag}` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/PUT_users-UserID-tags-Tag>`__.
 
@@ -1107,10 +1108,10 @@ The *Tag* can be deleted as follows.
 
       .. code-block:: bash
 
-         nitropy nethsm --host $NETHSM_HOST delete-operator-tag e8836f4cf2c7fa968bf0 berlin
+         nitropy nethsm --host $NETHSM_HOST delete-operator-tag operator1 berlin
 
       .. code-block::
 
-         Deleted tag berlin for user 5d0d171c067e1f519b33 on the NetHSM localhost:8443
+         Deleted tag berlin for user operator1 on the NetHSM localhost:8443
    .. tab:: REST API
       Information about the `/users/{UserID}/tags/{Tag}` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/DELETE_users-UserID-tags-Tag>`__.

--- a/nethsm/administration.rst
+++ b/nethsm/administration.rst
@@ -982,7 +982,7 @@ A user account can be deleted as follows.
       Information about the `/users/{UserID}` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/DELETE_users-UserID>`__.
 
 List Users
-~~~~~~~~~
+~~~~~~~~~~
 
 List the users on the NetHSM.
 

--- a/nethsm/administration.rst
+++ b/nethsm/administration.rst
@@ -880,19 +880,19 @@ Each user account configured on the NetHSM has one of the following *Roles* assi
 +-----------------+-------------------------------------------------------------+
 | Role            | Description                                                 |
 +=================+=============================================================+
-| *Administrator* | A user account with this Role has access to all            |
+| *Administrator* | A user account with this Role has access to all             |
 |                 | operations provided by the NetHSM, except for key usage     |
 |                 | operations, i.e. message signing and decryption.            |
 +-----------------+-------------------------------------------------------------+
-| *Operator*      | A user account with this Role has access to all key usage  |
+| *Operator*      | A user account with this Role has access to all key usage   |
 |                 | operations, a read-only subset of key management operations |
 |                 | and user management operations allowing changes to their    |
 |                 | own account only.                                           |
 +-----------------+-------------------------------------------------------------+
-| *Metrics*       | A user account with this Role has access to read-only      |
+| *Metrics*       | A user account with this Role has access to read-only       |
 |                 | metrics operations only.                                    |
 +-----------------+-------------------------------------------------------------+
-| *Backup*        | A user account with this Role has access to the operations |
+| *Backup*        | A user account with this Role has access to the operations  |
 |                 | required to initiate a system backup only.                  |
 +-----------------+-------------------------------------------------------------+
 

--- a/nethsm/operation.rst
+++ b/nethsm/operation.rst
@@ -367,7 +367,7 @@ The *Operator* users can see all keys, but only use those with at least one corr
 If a key has no *Tag* it can be used by all *Operator* users.
 A key can not be modified by an *Operator* user.
 
-To learn about how to use *Tags* on *Operator* accounts, please refer to `Tags for Users <administration.html#tags-for-users>`__.
+To learn about how to use *Tags* on *Operator* accounts, please refer to chapter `Tags for Users <administration.html#tags-for-users>`__.
 
 .. note::
    *Tags* are managed without restrictions by users with the *Administrator* role.
@@ -591,7 +591,7 @@ Encrypt
 ~~~~~~~
 
 The NetHSM can not encrypt data, but it provides the public key which can be used for encryption.
-Please refer to the `Show Key Details <operation.html#show-key-details>`__ to learn more about how the retrieve the public key.
+To learn about how to retrieve the public key, please refer to chapter `Show Key Details <operation.html#show-key-details>`__.
 
 Data can be encrypted with OpenSSL as follows.
 

--- a/nethsm/operation.rst
+++ b/nethsm/operation.rst
@@ -709,15 +709,6 @@ From the digest a signature can be created as follows.
    .. tab:: REST API
       Information about the `/keys/{KeyID}/sign` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/POST_keys-KeyID-sign>`__.
 
-      .. code-block::
-
-         curl -X 'POST' \
-            'https://nethsmdemo.nitrokey.com/api/v1/keys/myFirstKey/sign' \
-            -H 'accept: application/json' \
-            -H 'Content-Type: application/json' \
-            -d '{"mode": "PKCS1", "message": "nhrfotu32409ru0rgert45z54z099u23r03498uhtr=="}' \
-            | base64 -d > data.sig
-
 The created signature can be verified with OpenSSL as follows.
 
 .. code-block:: bash

--- a/nethsm/operation.rst
+++ b/nethsm/operation.rst
@@ -395,11 +395,11 @@ The *Tag* can be added as follows.
 
       .. code-block:: bash
 
-         $ nitropy nethsm --host $NETHSM_HOST add-key-tag 8925c71517637fc6422b berlin
+         $ nitropy nethsm --host $NETHSM_HOST add-key-tag myFirstKey berlin
 
       .. code-block::
 
-         Added tag berlin for key 8925c71517637fc6422b on the NetHSM localhost:8443
+         Added tag berlin for key myFirstKey on the NetHSM localhost:8443
    .. tab:: REST API
       Information about the `/keys/{KeyID}/restrictions/tags/{Tag}` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/PUT_keys-KeyID-restrictions-tags-Tag>`__.
 
@@ -425,11 +425,11 @@ The *Tag* can be deleted as follows.
 
       .. code-block:: bash
 
-         $ nitropy nethsm --host $NETHSM_HOST delete-key-tag 8925c71517637fc6422b berlin
+         $ nitropy nethsm --host $NETHSM_HOST delete-key-tag myFirstKey berlin
 
       .. code-block::
 
-         Deleted tag berlin for key 8925c71517637fc6422b on the NetHSM localhost:8443
+         Deleted tag berlin for key myFirstKey on the NetHSM localhost:8443
    .. tab:: REST API
       Information about the `/keys/{KeyID}/restrictions/tags/{Tag}` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/DELETE_keys-KeyID-restrictions-tags-Tag>`__.
 

--- a/nethsm/operation.rst
+++ b/nethsm/operation.rst
@@ -359,47 +359,6 @@ The public key can be inspected for example with OpenSSL as follows.
    .. tab:: REST API
       Information about the `/keys/{KeyID}/public.pem` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/GET_keys-KeyID-public-pem>`__.
 
-      .. code-block::
-
-         curl -X 'GET' \
-            'https://nethsmdemo.nitrokey.com/api/v1/keys/myFirstKey/public.pem' \
-            -H 'accept: application/x-pem-file' \
-            | openssl rsa -pubin -text
-
-      .. code-block::
-
-         Public-Key: (2048 bit)
-         Modulus:
-            00:af:ad:97:1c:f5:8c:0d:d1:1f:d8:8d:56:12:94:
-            b1:1a:8c:18:fd:f4:05:f2:53:0f:b6:fd:c4:51:02:
-            44:fc:f2:d6:06:f7:a1:17:c1:b4:41:8d:c0:55:56:
-            77:7a:d9:50:5a:22:ab:78:eb:86:0f:1e:0d:af:63:
-            c5:35:80:2e:e5:ff:89:3f:62:5c:d6:5b:05:34:e6:
-            05:f0:3f:36:44:5e:35:30:1c:92:6d:04:7e:93:ee:
-            38:37:fd:38:07:46:a1:4c:10:b1:5f:ea:2f:14:7e:
-            d2:77:a4:b3:bf:13:0f:6b:b1:0a:be:16:8e:b0:b6:
-            e0:ca:b3:e5:15:9c:50:9e:12:04:a8:94:42:4a:8e:
-            43:45:10:fe:09:10:8f:a4:65:ec:55:78:05:6c:9a:
-            cd:8a:58:76:d6:2f:0e:64:27:2d:e2:70:b6:39:2d:
-            7d:d4:c7:83:2a:60:87:e2:d8:eb:7c:b3:30:38:a2:
-            44:f3:32:a5:c2:17:6d:03:5b:8c:63:8f:7e:26:e6:
-            82:e3:c1:94:16:c2:d8:c1:b2:e9:d7:bd:b7:52:fd:
-            4f:8d:98:c2:e6:36:d4:85:27:03:d2:ef:48:fa:23:
-            6b:ab:39:c0:7a:46:b8:75:6b:09:f6:38:00:fa:1e:
-            a1:6e:54:a0:0a:cd:08:dc:c5:8e:b0:c5:f1:fd:8e:
-            4f:19
-         Exponent: 65537 (0x10001)
-         writing RSA key
-         -----BEGIN PUBLIC KEY-----
-         MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr62XHPWMDdEf2I1WEpSx
-         GowY/fQF8lMPtv3EUQJE/PLWBvehF8G0QY3AVVZ3etlQWiKreOuGDx4Nr2PFNYAu
-         5f+JP2Jc1lsFNOYF8D82RF41MBySbQR+k+44N/04B0ahTBCxX+ovFH7Sd6SzvxMP
-         a7EKvhaOsLbgyrPlFZxQnhIEqJRCSo5DRRD+CRCPpGXsVXgFbJrNilh21i8OZCct
-         4nC2OS191MeDKmCH4tjrfLMwOKJE8zKlwhdtA1uMY49+JuaC48GUFsLYwbLp1723
-         Uv1PjZjC5jbUhScD0u9I+iNrqznAeka4dWsJ9jgA+h6hblSgCs0I3MWOsMXx/Y5P
-         GQIDAQAB
-         -----END PUBLIC KEY-----
-
 Tags for Keys
 ~~~~~~~~~~~~~
 

--- a/nethsm/operation.rst
+++ b/nethsm/operation.rst
@@ -651,15 +651,6 @@ The data can be decrypted as follows.
    .. tab:: REST API
       Information about the `/keys/{KeyID}/decrypt` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/POST_keys-KeyID-decrypt>`__.
 
-      .. code-block::
-
-         curl -X 'POST' \
-            'https://nethsmdemo.nitrokey.com/api/v1/keys/myFirstKey/decrypt' \
-            -H 'accept: application/json' \
-            -H 'Content-Type: application/json' \
-            -d '{"mode": "RAW", "encrypted": "nhrfotu32409ru0rgert45z54z099u23r03498uhtr=="}' \
-            | base64 -d
-
 Sign
 ~~~~
 

--- a/nethsm/operation.rst
+++ b/nethsm/operation.rst
@@ -191,6 +191,37 @@ The import can be initiated as follows.
    .. tab:: REST API
       Information about the `/keys` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/POST_keys>`__.
 
+Delete Key
+~~~~~~~~~~
+
+The NetHSM can delete keys from the *Key Store*.
+
+.. tabs::
+   .. tab:: nitropy
+      **Required Role**
+
+      This operation requires an authentication with the *Administrator* role.
+
+      **Arguments**
+
+      +------------+---------------------------------+
+      | Argument   | Description                     |
+      +============+=================================+
+      | ``KEY_ID`` | The key ID of the key to delete |
+      +------------+---------------------------------+
+
+      **Example**
+
+      .. code-block:: bash
+
+         $ nitropy nethsm --host $NETHSM_HOST delete-key myFirstKey
+      
+      .. code-block::
+
+         Key myFirstKey deleted on NetHSM localhost:8443
+   .. tab:: REST API
+      Information about the `/keys/{KeyID}` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/DELETE_keys-KeyID>`__.
+
 List Keys
 ~~~~~~~~~
 

--- a/nethsm/operation.rst
+++ b/nethsm/operation.rst
@@ -597,7 +597,7 @@ Data can be encrypted with OpenSSL as follows.
 
 .. code-block:: bash
 
-   $ echo 'NetHSM rulez!' | openssl pkeyutl -encrypt -certin -inkey public.pem | base64 > data.crypt
+   $ echo 'NetHSM rulez!' | openssl pkeyutl -encrypt -pubin -inkey public.pem | base64 > data.crypt
 
 This writes the encrypted and base64 encoded message ``NetHSM rulez!`` into the file ``data.crypt``.
 


### PR DESCRIPTION
* Fix Sphinx syntax errors.
* Add "Delete Key" chapter.
* Add "List Users" chapter.
* Unify name for generated operator user throughout the documentation.
* Unify name for generated key throughout the documentation.
* Remove old curl example leftovers.
* Change OpenSSL command to use `-pubin`, instead of `-certin`. This makes it possible for the user to follow the examples with the same setup. Otherwise, they would have to create a certificate first.
* Smaller formulation improvements.