### PR TITLE
[Nitrokey App 2] Mention required udev rules for non-root users

### DIFF
--- a/software/nk-app2/linux/index.rst
+++ b/software/nk-app2/linux/index.rst
@@ -11,4 +11,5 @@ Installation
 
 1. `Download <https://github.com/Nitrokey/nitrokey-app2/releases>`__ the binary for Linux Nitrokey App 2.
 2. Extract the archive and set the binary as executable.
-3. Execute the binary and have fun.
+3. `Set up the udev rules for nitropy <../../nitropy/linux/udev.rst>`__
+4. Execute the binary and have fun.


### PR DESCRIPTION
Udev rules are required on Linux for updating the firmware without root privileges otherwise firmware updates fail with a generic error message.