### PR TITLE
Fix PIV documentation formatting

### DIFF
--- a/nitrokey3/windows/piv.rst
+++ b/nitrokey3/windows/piv.rst
@@ -26,11 +26,13 @@ Prerequisites
 
 The key is generated in slot 9A (authentication).
 
-``pivy-tool generate 9A -a rsa2048``
-
 ::
 
-   If the administration key is not the default one, it can be specified with `-A 3des -K 010203040506070801020304050607080102030405060708` . The argument to `-A` can also be `aes256`, and the argument to `-K` is the key in hexadecimal. 
+      pivy-tool generate 9A -a rsa2048
+
+.. note::
+
+   If the administration key is not the default one, it can be specified with ``-A 3des -K 010203040506070801020304050607080102030405060708`` . The argument to ``-A`` can also be ``aes256``, and the argument to ``-K`` is the key in hexadecimal. 
 
 The user PIN can also be specified with ``-P 123456``, or ``-P <value>`` if it is not the default. If ``-P`` is not provided, it will be asked for after key generation.
 


### PR DESCRIPTION
I noticed that parts of the PIV documentation was formatted weirdly. This PR fixes it.

# Before:

![image](https://github.com/Nitrokey/nitrokey-documentation/assets/109070476/dea731bf-993c-4900-886a-02ff1703b502)

---

# After:

![image](https://github.com/Nitrokey/nitrokey-documentation/assets/109070476/4fc2ab52-15d8-4a0f-ac53-0a4af0023ca1)
