### PR TITLE
NitroPhone, NitroTablet: fixed the link for the rotation app 

### DIFF
--- a/nitrophone/apps.rst
+++ b/nitrophone/apps.rst
@@ -57,7 +57,7 @@ Recommended Apps
 Recommendation for Sensor-Less Devices
 ######################################
 
-If you have a NitroPhone or NitroTablet without rotation sensor, you could use Rotation Control <https://play.google.com/store/apps/details?id=org.crape.rotationcontrol>`__ to rotate your screen manually.
+If you have a NitroPhone or NitroTablet without rotation sensor, you could use `Rotation Control <https://play.google.com/store/apps/details?id=org.crape.rotationcontrol>`__ to rotate your screen manually.
 
 Permissions of Individual Apps
 ##############################


### PR DESCRIPTION
- fixed the hyperlink syntax