### PR TITLE
Fix typo in URL protocol.

### DIFF
--- a/locales/bg/LC_MESSAGES/string.po
+++ b/locales/bg/LC_MESSAGES/string.po
@@ -14994,10 +14994,10 @@ msgstr "Сега GnuPG ще поиска *ПИН кода на админист�
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*ПИН* и *PUK* за PIV (Personal Identity Verification) картата могат да "
-"бъдат зададени с `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"бъдат зададени с `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/cs/LC_MESSAGES/string.po
+++ b/locales/cs/LC_MESSAGES/string.po
@@ -14651,10 +14651,10 @@ msgstr ""
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN* a *PUK* pro kartu PIV (Personal Identity Verification) lze nastavit"
-" pomocí `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+" pomocí `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/da/LC_MESSAGES/string.po
+++ b/locales/da/LC_MESSAGES/string.po
@@ -14784,10 +14784,10 @@ msgstr "GnuPG vil nu bede om *Admin PIN*, og *Reset Code*."
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN* og *PUK* for PIV-kort (Personal Identity Verification) kan "
-"indstilles med `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"indstilles med `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/de/LC_MESSAGES/string.po
+++ b/locales/de/LC_MESSAGES/string.po
@@ -15226,10 +15226,10 @@ msgstr "GnuPG fragt nun nach der *Admin PIN* und dem *Reset Code*."
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "Die *PIN* und *PUK* für PIV (Personal Identity Verification) Karten "
-"können mit `pivy-tool <hhttps://github.com/arekinath/pivy>`__ eingestellt"
+"können mit `pivy-tool <https://github.com/arekinath/pivy>`__ eingestellt"
 " werden."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9

--- a/locales/el/LC_MESSAGES/string.po
+++ b/locales/el/LC_MESSAGES/string.po
@@ -15301,11 +15301,11 @@ msgstr "Το GnuPG θα ζητήσει τώρα το *Admin PIN*, και το *R
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "Τα *PIN* και *PUK* για την κάρτα PIV (Personal Identity Verification) "
 "μπορούν να ρυθμιστούν με το `pivy-tool "
-"<hhttps://github.com/arekinath/pivy>`__."
+"<https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/es/LC_MESSAGES/string.po
+++ b/locales/es/LC_MESSAGES/string.po
@@ -15087,11 +15087,11 @@ msgstr ""
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "El *PIN* y *PUK* para la tarjeta PIV (Personal Identity Verification) "
 "pueden configurarse con `pivy-tool "
-"<hhttps://github.com/arekinath/pivy>`__."
+"<https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/et/LC_MESSAGES/string.po
+++ b/locales/et/LC_MESSAGES/string.po
@@ -14636,10 +14636,10 @@ msgstr "GnuPG küsib nüüd *Admin PIN* ja *Reset Code*."
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN-koodi* ja *PUK* PIV (Personal Identity Verification) kaardile saab "
-"määrata `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"määrata `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/fi/LC_MESSAGES/string.po
+++ b/locales/fi/LC_MESSAGES/string.po
@@ -14779,10 +14779,10 @@ msgstr "GnuPG kysyy nyt *Admin PIN* ja *Reset Code*."
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN-koodi* ja *PUK* PIV (Personal Identity Verification) -korttia varten"
-" voidaan asettaa `pivy-toolilla <hhttps://github.com/arekinath/pivy>`__."
+" voidaan asettaa `pivy-toolilla <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/fr/LC_MESSAGES/string.po
+++ b/locales/fr/LC_MESSAGES/string.po
@@ -15234,11 +15234,11 @@ msgstr ""
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "Le *PIN* et le *PUK* pour la carte PIV (Personal Identity Verification) "
 "peuvent être définis à l'aide de `pivy-tool "
-"<hhttps://github.com/arekinath/pivy>`__."
+"<https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/hu/LC_MESSAGES/string.po
+++ b/locales/hu/LC_MESSAGES/string.po
@@ -15003,10 +15003,10 @@ msgstr "A GnuPG most a *Admin PIN kódot*, és a *Reset kódot* fogja kérni."
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "A *PIN* és *PUK* a PIV (Personal Identity Verification) kártyához a "
-"`pivy-tool <hhttps://github.com/arekinath/pivy>`__ segítségével állítható"
+"`pivy-tool <https://github.com/arekinath/pivy>`__ segítségével állítható"
 " be."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9

--- a/locales/it/LC_MESSAGES/string.po
+++ b/locales/it/LC_MESSAGES/string.po
@@ -15014,10 +15014,10 @@ msgstr "GnuPG chiederà ora il *Admin PIN*, e il *Reset Code*."
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN* e *PUK* per la carta PIV (Personal Identity Verification) possono "
-"essere impostati con `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"essere impostati con `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/ja/LC_MESSAGES/string.po
+++ b/locales/ja/LC_MESSAGES/string.po
@@ -12972,10 +12972,10 @@ msgstr "GnuPG は*Admin PIN* と*Reset Code* を要求します。"
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN* と*PUK* for PIV (Personal Identity Verification) Card は、`pivy-"
-"tool<hhttps://github.com/arekinath/pivy>`__ で設定できます。"
+"tool<https://github.com/arekinath/pivy>`__ で設定できます。"
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/lt/LC_MESSAGES/string.po
+++ b/locales/lt/LC_MESSAGES/string.po
@@ -14867,10 +14867,10 @@ msgstr "Dabar \"GnuPG\" paprašys *administratoriaus PIN kodo* ir *atstatymo kod
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN* ir *PUK* PIV (angl. Personal Identity Verification) kortelei galima"
-" nustatyti naudojant `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+" nustatyti naudojant `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/lv/LC_MESSAGES/string.po
+++ b/locales/lv/LC_MESSAGES/string.po
@@ -14746,10 +14746,10 @@ msgstr ""
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN* un *PUK* PIV (Personal Identity Verification) kartei var iestatīt "
-"ar `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"ar `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/nl/LC_MESSAGES/string.po
+++ b/locales/nl/LC_MESSAGES/string.po
@@ -14985,10 +14985,10 @@ msgstr "GnuPG vraagt nu om de *Admin PIN* en de *Reset Code*."
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "De *PIN* en *PUK* voor PIV (Personal Identity Verification)-kaart kunnen "
-"worden ingesteld met `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"worden ingesteld met `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/pl/LC_MESSAGES/string.po
+++ b/locales/pl/LC_MESSAGES/string.po
@@ -14911,10 +14911,10 @@ msgstr "GnuPG poprosi teraz o *Admin PIN*, oraz *Reset Code*."
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN* i *PUK* dla karty PIV (Personal Identity Verification) można "
-"ustawić za pomocą `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"ustawić za pomocą `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/pt/LC_MESSAGES/string.po
+++ b/locales/pt/LC_MESSAGES/string.po
@@ -14390,7 +14390,7 @@ msgstr ""
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9

--- a/locales/ro/LC_MESSAGES/string.po
+++ b/locales/ro/LC_MESSAGES/string.po
@@ -15051,10 +15051,10 @@ msgstr "GnuPG vă va cere acum *Admin PIN*, și *Reset Code*."
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN* și *PUK* pentru cardul PIV (Personal Identity Verification) pot fi "
-"setate cu `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"setate cu `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/ru/LC_MESSAGES/string.po
+++ b/locales/ru/LC_MESSAGES/string.po
@@ -14928,10 +14928,10 @@ msgstr "Теперь GnuPG попросит ввести *PIN-код админ�
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN* и *PUK* для PIV (Personal Identity Verification) Card можно "
-"установить с помощью `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"установить с помощью `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/sk/LC_MESSAGES/string.po
+++ b/locales/sk/LC_MESSAGES/string.po
@@ -14719,10 +14719,10 @@ msgstr "GnuPG teraz požiada o zadanie kódu PIN administrátora ** , a kódu *R
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN* a *PUK* pre kartu PIV (Personal Identity Verification) možno "
-"nastaviť pomocou `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"nastaviť pomocou `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/sl/LC_MESSAGES/string.po
+++ b/locales/sl/LC_MESSAGES/string.po
@@ -14708,10 +14708,10 @@ msgstr "GnuPG bo zdaj zahteval kodo *Admin PIN* in kodo *Reset*."
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "*PIN* in *PUK* za kartico PIV (Personal Identity Verification) lahko "
-"nastavite z orodjem `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"nastavite z orodjem `pivy-tool <https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/string.pot
+++ b/locales/string.pot
@@ -9688,7 +9688,7 @@ msgid "GnuPG will now ask for the *Admin PIN*, and the *Reset Code*."
 msgstr ""
 
 #: ../nitrokey3/shared/set-pins.rst.inc:6
-msgid "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+msgid "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9

--- a/locales/sv/LC_MESSAGES/string.po
+++ b/locales/sv/LC_MESSAGES/string.po
@@ -14754,11 +14754,11 @@ msgstr "GnuPG kommer nu att be om *Admin PIN*, och *Reset Code*."
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "PIN-koden ** och PUK-koden ** för PIV-kort (Personal Identity "
 "Verification) kan ställas in med `pivy-tool "
-"<hhttps://github.com/arekinath/pivy>`__."
+"<https://github.com/arekinath/pivy>`__."
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/locales/zh_CN/LC_MESSAGES/string.po
+++ b/locales/zh_CN/LC_MESSAGES/string.po
@@ -12552,10 +12552,10 @@ msgstr "GnuPG现在会要求输入*管理密码* ，以及*重置代码* 。"
 #: ../nitrokey3/shared/set-pins.rst.inc:6
 msgid ""
 "The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be "
-"set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__."
+"set with `pivy-tool <https://github.com/arekinath/pivy>`__."
 msgstr ""
 "PIV（个人身份验证）卡的*PIN* 和*PUK* 可以用`pivy-"
-"tool<hhttps://github.com/arekinath/pivy>`__设置。"
+"tool<https://github.com/arekinath/pivy>`__设置。"
 
 #: ../nitrokey3/shared/set-pins.rst.inc:9
 msgid "PIN"

--- a/nitrokey3/shared/set-pins.rst.inc
+++ b/nitrokey3/shared/set-pins.rst.inc
@@ -161,7 +161,7 @@ It is useful in situations when the user of the Nitrokey should be able to unblo
 PIV
 ---
 
-The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be set with `pivy-tool <hhttps://github.com/arekinath/pivy>`__.
+The *PIN* and *PUK* for PIV (Personal Identity Verification) Card can be set with `pivy-tool <https://github.com/arekinath/pivy>`__.
 
 PIN
 ^^^


### PR DESCRIPTION
The protocol for website to the pivy tool was `hhttps` instead of `https` which made the links not working.