### PR TITLE
Fix rst warnings

### DIFF
--- a/nethsm/faq.rst
+++ b/nethsm/faq.rst
@@ -2,7 +2,7 @@ Frequently Asked Questions (FAQ)
 ================================
 
 Scalability, High Availability: How to synchronize a cluster of multiple instances?
-----------------------------------------------------------------
+-----------------------------------------------------------------------------------
 
 NetHSM is stateless, so that several NetHSM devices can be used to enable extremely high throughput and high availability. The PKCS#11 module supports round-robin schedule for a cluster of NetHSM instances. Multiple instances of NetHSM can be synchronized via encrypted backups. For this a separate system downloads and uploads backup files between the instances. This can be a scripted system utilizing pynitrokey. This separate system doesn't has access to the backup data in clear text because the backup files are encrypted.
 

--- a/nethsm/metrics.rst
+++ b/nethsm/metrics.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Metrics
 =======
 


### PR DESCRIPTION
This PR marks the `metrics.rst` document of NetHSM as orphan to not throw warnings and also fixes an underline too short warning.