### PR TITLE
Explain 'pcsc-shared' in nitrokey3/linux/fedora-gnupg-configuration

### DIFF
--- a/nitrokey3/linux/fedora-gnupg-configuration.rst
+++ b/nitrokey3/linux/fedora-gnupg-configuration.rst
@@ -50,5 +50,9 @@ Check system configuration
 
 2. The *scdaemon* requires the *libpcsclite* library to connect to *pcscd*.
    The path to the pcsc library can be set explicitly with ``echo "pcsc-driver /usr/lib64/libpcsclite.so.1" >> ~/.gnupg/scdaemon.conf``.
-   Alternatively, the library can also be made available with a symlink as follows ``ln -s /usr/lib64/libpcsclite.so.1``.
+   Alternatively, the library can also be made available with a symlink as follows ``ln -s /usr/lib64/libpcsclite.so.1 /usr/lib64/libpcsclite.so``.
    Make sure the ``~/.gnupg/scdaemon.conf`` file has no conflicting settings applied.
+
+3. The *scdaemon* by default expects exclusive access to *pcscd*, to avoid potential issues with concurrent modifications of information on the card.
+   This causes access to fail if other clients, usually web browsers, accessed the card, even if only for reading.
+   Shared access can be enabled with ``echo "pcsc-shared" >> ~/.gnupg/scdaemon.conf`` (in GnuPG version 2.2.28 or higher).


### PR DESCRIPTION
I added a bullet point explaining why and how to enable  `pcsc-shared` in scdaemon.

A commonly encountered issue with scdaemon is that it wants exclusive access to pcscd, causing gpg to fail without explanation when a browser is open. This doesn't seem to resolve until the browser is closed, making gpg essentially unusable. The `pcsc-shared` option in `~/.gnupg/scdaemon.conf` fixes this.

It isn't default, because it can cause problems when other clients concurrently write to the card. But as far as I understand, it's unlikely that a user has one client writing to the card while also making another operation with gpg/scdaemon.

References:
* https://wiki.archlinux.org/title/GnuPG#Shared_access_with_pcscd
* https://www.gnupg.org/documentation/manuals/gnupg/Scdaemon-Options.html
* gpg 2.2.28 release: https://lists.gnupg.org/pipermail/gnupg-announce/2021q2/000460.html

By the way, I'm fixing the `ln` command.