### PR TITLE
Add CI pipeline to check for build errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Continuous integration
+on:
+  push:
+    branches-ignore:
+      - "master"
+  pull_request:
+
+jobs:
+  build-error-check:
+    name: Check build error
+    runs-on: ubuntu-latest
+    container: python:3.11-slim
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Create virtual environment
+        run: |
+          python -m venv venv
+          . venv/bin/activate
+          pip install -r requirements.txt
+      - name: Build documentation
+        run: |
+          . venv/bin/activate
+          sphinx-build -W -j 1 -a -D language='en' -b html . __preview

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,23 @@ on:
   pull_request:
 
 jobs:
+  syntax-check:
+    name: Check syntax
+    runs-on: ubuntu-latest
+    container: python:3.11-slim
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Create virtual environment
+        run: |
+          python -m venv venv
+          . venv/bin/activate
+          pip install -r requirements.txt
+      - name: Syntax check
+        run: |
+          . venv/bin/activate
+          rstcheck --recursive --ignore-directives "tabs" fido2/ hsm/ nethsm/ nextbox/ nitrokey3/ nitropad/ nitropc/ nitrophone/ nitrowall/ pro/ software/ start/ storage/ u2f/
   build-error-check:
     name: Check build error
     runs-on: ubuntu-latest

--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -1,0 +1,2 @@
+[rstcheck]
+ignore_directives=tabs

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ MarkupSafe==2.1.2
 packaging==23.1
 Pygments==2.15.1
 requests==2.30.0
+rstcheck==6.2.0
 snowballstemmer==2.2.0
 soupsieve==2.4.1
 Sphinx==6.2.1


### PR DESCRIPTION
This PR introduces a CI pipeline with two checks.

1. Checks a full build of the documentation for warnings and errors during build.
2. Checks the syntax with the **rstcheck** tool.

The first check should from now on be mandatory to pass. The second gives and indicator if a merge introduces other problems and helps with future improvements. As it currently fails it has `continue-on-error` set.