### PR TITLE
Nethsm development

### DIFF
--- a/nethsm/integration.rst
+++ b/nethsm/integration.rst
@@ -31,7 +31,20 @@ The container can be executed as follows.
 
          $ podman run --rm -ti -p8443:8443 docker.io/nitrokey/nethsm:testing 
 
-This will provide the REST API on the port `8443` via the HTTPS protocol.
+This will run NetHSM as a Unix process inside the container and expose the REST API on the port `8443` via the HTTPS protocol.
+
+Additionaly to running the NetHSM as a Unix process it can be run as a unikernel supported by KVM.
+
+The container can be executed as follows.
+
+.. tabs::
+   .. tab:: Docker
+      .. code-block:: bash
+
+         $ docker run -ti --rm -p 8443:8443 --device /dev/net/tun --device /dev/kvm --cap-add=NET_ADMIN nitrokey/nethsm:testing
+
+This will run NetHSM as a unikernel inside a KVM virtual machine.
+The container will expose the REST API, via the HTTPS protocol, on the interface `tap200` with the IP address `192.168.1.100` and port `8443`.
 
 .. important::
    The container uses a self-signed TLS certificate.

--- a/nethsm/integration.rst
+++ b/nethsm/integration.rst
@@ -6,7 +6,8 @@ The chapter describes processes for various tasks and aims at all user groups.
 REST-API
 ~~~~~~~~
 
-NetHSM's API specification is available in `OpenAPI format <https://nethsmdemo.nitrokey.com/api_docs/nethsm-api.yaml>`_,
+NetHSM's primary interface is a modern REST-API that guarantees best performance and functionality.
+The API specification is available in `OpenAPI format <https://nethsmdemo.nitrokey.com/api_docs/nethsm-api.yaml>`_,
 and can be inspected and tested in the `API browser <https://nethsmdemo.nitrokey.com/api_docs/index.html>`_.
 
 PKCS#11

--- a/nethsm/integration.rst
+++ b/nethsm/integration.rst
@@ -3,6 +3,12 @@ Integration
 
 The chapter describes processes for various tasks and aims at all user groups.
 
+REST-API
+~~~~~~~~
+
+NetHSM's API specification is available in `OpenAPI format <https://nethsmdemo.nitrokey.com/api_docs/nethsm-api.yaml>`_,
+and can be inspected and tested in the `API browser <https://nethsmdemo.nitrokey.com/api_docs/index.html>`_.
+
 PKCS#11
 -------
 
@@ -90,9 +96,3 @@ This folder also contains the necessary documentation how to use it.
    The mode of SELinux can be requested with ``sestatus |grep "Current mode"``.
    If the mode is set to ``enforcing``, a change to the context is required.
    In this case the volume mount must be postfixed with ``:z``, resulting in ``-v "${PWD}/out:/out:z"``.
-
-REST-API
-~~~~~~~~
-
-NetHSM's API specification is available in `OpenAPI format <https://nethsmdemo.nitrokey.com/api_docs/nethsm-api.yaml>`_,
-and can be inspected and tested in the `API browser <https://nethsmdemo.nitrokey.com/api_docs/index.html>`_.


### PR DESCRIPTION
This PR makes changes to the chapter "Integration" of the NetHSM.

- Move chapter "REST-API" to the top of the page.
  - Change wording of the chapter.
- Add information about unikernel run to container instructions.