### PR TITLE
Fix hyperlinks to secure element reports

### DIFF
--- a/hsm/faq.rst
+++ b/hsm/faq.rst
@@ -84,10 +84,8 @@ Nitrokey HSM FAQ
 
 
 **Q:** Is the Nitrokey HSM 2 Common Criteria or FIPS certified?
-    The security controller's hardware and operating system are
-    Common Criteria certified (`Security Target`_; `HSM2 Report`_; See `here`_,
-    click "ICs, Smart Cards and Smart Card-Related Devices and Systems" and
-    search for "NXP JCOP 3 P60").
+    The security controller (NXP JCOP 3 P60) is Common Criteria EAL 5+ certified up to the OS
+    level (`Certificate <https://commoncriteriaportal.org/files/epfiles/NSCIB-certificate%2021-98209.pdf>`__, `Certification Report <https://commoncriteriaportal.org/files/epfiles/Certification%20Report%20NSCIB-CC-98209-CR5%20-%20version%203.0%20(2022-10-14).pdf>`__, `Security Target <https://commoncriteriaportal.org/files/epfiles/NSCIB-CC-98209_5-STLite.pdf>`__, `Java Card System Protection Profile Open Configuration, Version 3.0 <https://commoncriteriaportal.org/files/ppfiles/ANSSI-CC-profil_PP-2010-03en.pdf>`__).
 
 **Q:** How to import an existing key into the Nitrokey HSM?
     First, `set up`_ your Nitrokey HSM to use key backup and restore. Then use Smart Card Shell for importing. If your key is stored in a Java key store you can use `NitroKeyWrapper`_  instead.

--- a/nitrokey3/faq.rst
+++ b/nitrokey3/faq.rst
@@ -44,9 +44,8 @@ Nitrokey 3 FAQ
    Please refer to the chapter of your respective operating system (`Linux <linux/set-pins.html>`__, `Mac OS <mac/set-pins.html>`__, `Windows <windows/set-pins.html>`__).
 
 **Q:** Is the Nitrokey 3 Common Criteria or FIPS certified?
-   The secure element is Common Criteria EAL 6+ security certification up to OS 
-   level (See `here`_, click “ICs, Smart Cards and Smart Card-Related Devices and 
-   ystems” and search for: "NXP JCOP 4 SE050M”).
+   The secure element (SE050M) is Common Criteria EAL 6+ security certified up to the OS 
+   level (`Certificate <https://commoncriteriaportal.org/files/epfiles/NSCIB-CC-23-0075446_2-Cert.pdf>`__, `Certification Report <https://commoncriteriaportal.org/files/epfiles/NSCIB-CC-0075446-CR2-1.pdf>`__, `Security Target <https://commoncriteriaportal.org/files/epfiles/NSCIB-CC-0075446_2-STLite.pdf>`__, `Java Card Protection Profile - Open Configuration <https://commoncriteriaportal.org/files/ppfiles/pp0099b_pdf.pdf>`__).
 
 **Q:** How to use Nitrokey 3 with Azure Entra ID (Active Directory)?
    After `disabling Enforce Attestation`_ Nitrokey 3 is supported by Azure Entra ID out of the box.

--- a/pro/faq.rst
+++ b/pro/faq.rst
@@ -48,11 +48,10 @@ Nitrokey Pro 2 FAQ
     Nitrokey Pro contains a tamper resistant smart card.
 
 **Q:** Is the Nitrokey Pro Common Criteria or FIPS certified?
-    The security controller's hardware is Common Criteria certified (`Report`_;
-    See `here`_, click "ICs, Smart Cards and Smart Card-Related Devices and
-    Systems" and search for "NXP Smart Card Controller P5CD081V1A and its major
+    The security controller (NXP Smart Card Controller P5CD081V1A and its major
     configurations P5CC081V1A, P5CN081V1A, P5CD041V1A, P5CD021V1A and P5CD016V1A
-    each with IC dedicated Software").
+    each with IC dedicated Software) is Common Criteria EAL 5+ certified up to the OS
+    level (`Certification Report <https://commoncriteriaportal.org/files/epfiles/0555a_pdf.pdf>`__, `Security Target <https://commoncriteriaportal.org/files/epfiles/0555b_pdf.pdf>`__, `Maintenance Report <https://commoncriteriaportal.org/files/epfiles/0555_ma1a_pdf.pdf>`__, `Maintenance ST <https://commoncriteriaportal.org/files/epfiles/0555_ma1b_pdf.pdf>`__).
 
 **Q:** How can I use the True Random Number Generator (TRNG) of the Nitrokey Pro for my applications?
     Both devices are compatible to the OpenPGP Card, so that `scdrand`_ should work. `This script`_ may be useful.

--- a/shared-faqs/hyperlinks.rst.inc
+++ b/shared-faqs/hyperlinks.rst.inc
@@ -1,13 +1,5 @@
 
 .. _frontpage: https://nitrokey.com/
-.. _Cure53: https://cure53.de
-.. _independent security audit: https://www.nitrokey.com/news/2015/nitrokey-storage-got-great-results-3rd-party-security-audit
-.. _Report: https://www.commoncriteriaportal.org/files/epfiles/0555a_pdf.pdf
-.. _here: https://www.commoncriteriaportal.org/products/
-.. _HSM Report: https://www.commoncriteriaportal.org/files/epfiles/0515a.pdf
-.. _HSM2 Report: https://www.commoncriteriaportal.org/files/epfiles/[CR]%20NSCIB-CC-98209-CR3.pdf
-.. _Security Target: https://www.commoncriteriaportal.org/files/epfiles/[ST-Lite]%20ST-Lite_JCOP3_P60_v3.8.pdf
-
 .. _WebAuthn.io: https://webauthn.io/
 .. _webautn.bin.coffee: https://webauthn.bin.coffee/
 .. _chrome://settings/securityKeys: chrome://settings/securityKeys

--- a/storage/faq.rst
+++ b/storage/faq.rst
@@ -63,12 +63,11 @@ non-volatile (encrypted) storage, the :doc:`Nitrokey Pro 2 FAQ <../pro/faq>` als
     Nitrokey Storage contains a tamper resistant smart card.
 
 **Q:** Is the Nitrokey Storage Common Criteria or FIPS certified?
-    `Cure53`_ has performed an `independent security audit`_ of the hardware,
-    firmware, and Nitrokey App. The security controller's hardware is Common
-    Criteria certified (`Report`_; See `here`_, click "ICs, Smart Cards and
-    Smart Card-Related Devices and Systems" and search for "NXP Smart Card
-    Controller P5CD081V1A and its major configurations P5CC081V1A, P5CN081V1A,
-    P5CD041V1A, P5CD021V1A and P5CD016V1A each with IC dedicated Software").
+    The security controller (NXP Smart Card Controller P5CD081V1A and its major
+    configurations P5CC081V1A, P5CN081V1A, P5CD041V1A, P5CD021V1A and P5CD016V1A
+    each with IC dedicated Software) is Common Criteria EAL 5+ certified up to the OS
+    level (`Certification Report <https://commoncriteriaportal.org/files/epfiles/0555a_pdf.pdf>`__, `Security Target <https://commoncriteriaportal.org/files/epfiles/0555b_pdf.pdf>`__, `Maintenance Report <https://commoncriteriaportal.org/files/epfiles/0555_ma1a_pdf.pdf>`__, `Maintenance ST <https://commoncriteriaportal.org/files/epfiles/0555_ma1b_pdf.pdf>`__`).
+    Additionally `Cure53 <https://cure53.de>`__ has performed an `independent security audit <https://www.nitrokey.com/news/2015/nitrokey-storage-got-great-results-3rd-party-security-audit>`__ of the hardware, firmware, and Nitrokey App.
 
 **Q:** How can I use the True Random Number Generator (TRNG) of the Nitrokey Storage for my applications?
     Both devices are compatible to the OpenPGP Card, so that `scdrand`_ should work. `This script`_ may be useful.


### PR DESCRIPTION
This PR fixes hyperlinks to the secure element reports, which caused the CI to fail.