### PR TITLE
Update troubleshooting for Arch Linux based systems

### DIFF
--- a/software/nk-app2/keepassxc.rst
+++ b/software/nk-app2/keepassxc.rst
@@ -102,3 +102,4 @@ If the Nirokey 3 device is not recognised by `KeePassXC <https://keepassxc.org/>
 
    flatpak install flathub org.keepassxc.KeePassXC
 
+* Install ``ccid`` on Arch Linux based systems. See also: `Arch wiki: Nitrokey <https://wiki.archlinux.org/title/Nitrokey>`__.


### PR DESCRIPTION
For using KeepassXC together with Nitrokey 3, on Arch Linux based systems it is necessary to install `ccid`. Otherwise, Nitrokey 3 will not be detected by KeepassXC.