### PR TITLE
NetHSM testing and production container

### DIFF
--- a/source/components/nethsm/container.rst
+++ b/source/components/nethsm/container.rst
@@ -1,0 +1,47 @@
+Container
+^^^^^^^^^
+
+For the NetHSM two container images are available for testing and production.
+
+The container image is distributed as an OCI image and can be obtained from `Docker Hub <https://hub.docker.com/r/nitrokey/nethsm>`_.
+It can be run locally with a compatible executor, e.g. Docker or Podman.
+
+Compared to the NetHSM hardware the following functions are not implemented at software container's REST API:
+
+* network configuration
+* factory reset
+* reboot
+* software update
+
+The container can be executed as follows.
+
+.. tabs::
+   .. tab:: Docker
+      .. code-block:: bash
+
+         $ sudo docker run --rm -ti -p8443:8443 nitrokey/nethsm:testing
+
+   .. tab:: Podman
+      .. code-block:: bash
+
+         $ podman run --rm -ti -p8443:8443 docker.io/nitrokey/nethsm:testing 
+
+This will run NetHSM as a Unix process inside the container and expose the REST API on the port `8443` via the HTTPS protocol.
+
+Additionaly to running the NetHSM as a Unix process it can be run as a unikernel supported by KVM.
+
+The container can be executed as follows.
+
+.. tabs::
+   .. tab:: Docker
+      .. code-block:: bash
+
+         $ docker run -ti --rm -p 8443:8443 --device /dev/net/tun --device /dev/kvm --cap-add=NET_ADMIN nitrokey/nethsm:testing
+
+This will run NetHSM as a unikernel inside a KVM virtual machine.
+The container will expose the REST API, via the HTTPS protocol, on the interface `tap200` with the IP address `192.168.1.100` and port `8443`.
+
+.. important::
+   The container uses a self-signed TLS certificate.
+   Make sure to use the correct connection settings to establish a connection.
+   Please refer to chapter `NetHSM introduction <index.html>`__ to learn more.

--- a/source/components/nethsm/container/container-hardware-restriction.rst.inc
+++ b/source/components/nethsm/container/container-hardware-restriction.rst.inc
@@ -1,0 +1,6 @@
+Compared to the NetHSM hardware the following functions are not implemented at software container's REST API:
+
+* Network configuration
+* Factory reset
+* Reboot
+* Software update

--- a/source/components/nethsm/container/index.rst
+++ b/source/components/nethsm/container/index.rst
@@ -1,20 +1,9 @@
 Container
 =========
 
-Software container images of NetHSM are available for testing and production.
-They are distributed as OCI images and can be run locally with a compatible executor such as Docker and Podman.
-
-Compared to the NetHSM hardware the following functions are not implemented at software container's REST API:
-
-* Network configuration
-* Factory reset
-* Reboot
-* Software update
-
-Refer to the following chapters to learn more about the respective differences.
+Please refer to the following chapters to learn more about the NetHSM container images.
 
 .. toctree::
-   :hidden:
    :maxdepth: 1
    :glob:
 

--- a/source/components/nethsm/container/index.rst
+++ b/source/components/nethsm/container/index.rst
@@ -1,0 +1,21 @@
+Container
+=========
+
+Software container images of NetHSM are available for testing and production. They are distributed as OCI images and can be run locally with a compatible executor such as Docker and Podman.
+
+Compared to the NetHSM hardware the following functions are not implemented at software container's REST API:
+
+* Network configuration
+* Factory reset
+* Reboot
+* Software update
+
+Refer to the following chapters to learn more about the respective differences.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :glob:
+
+   production-image.rst
+   test-image.rst

--- a/source/components/nethsm/container/index.rst
+++ b/source/components/nethsm/container/index.rst
@@ -1,7 +1,8 @@
 Container
 =========
 
-Software container images of NetHSM are available for testing and production. They are distributed as OCI images and can be run locally with a compatible executor such as Docker and Podman.
+Software container images of NetHSM are available for testing and production.
+They are distributed as OCI images and can be run locally with a compatible executor such as Docker and Podman.
 
 Compared to the NetHSM hardware the following functions are not implemented at software container's REST API:
 

--- a/source/components/nethsm/container/production-image.rst
+++ b/source/components/nethsm/container/production-image.rst
@@ -1,8 +1,11 @@
 Production Image
 ----------------
 
-The NetHSM production container is a product for paying customers only and can be purchased `here <https://www.nitrokey.com/contact>`__.
+The production image is provided for production envrionments with high security demands.
+It requires an external etcd key-value store and offers to run the NetHSM process with hardware-based separation (KVM).
+The connection between the NetHSM process and the key-value store is encrypted.
 
+The NetHSM production container is a product for paying customers only and can be purchased `here <https://www.nitrokey.com/contact>`__.
 The image can be obtained from `Nitrokey NetHSM registry <https://registry.git.nitrokey.com/distribution/nethsm>`_ using the credentials provided after purchase.
 
 .. warning::

--- a/source/components/nethsm/container/production-image.rst
+++ b/source/components/nethsm/container/production-image.rst
@@ -1,68 +1,3 @@
-Container
-=========
-
-Software container images of NetHSM are available for testing and production. They are distributed as OCI images and can be run locally with a compatible executor such as Docker and Podman.
-
-Compared to the NetHSM hardware the following functions are not implemented at software container's REST API:
-
-* Network configuration
-* Factory reset
-* Reboot
-* Software update
-
-Refer to the following chapters to learn more about the respective differences.
-
-Test Image
-----------
-
-The image can be obtained from `Docker Hub <https://hub.docker.com/r/nitrokey/nethsm>`_.
-
-.. warning::
-
-   Do not use the test image under any circumstances for production data and use cases.
-
-Tagging Policy
-^^^^^^^^^^^^^^
-
-The images in the repository are tagged with the Git commit hash from the main branch of the `repository <https://github.com/nitrokey/nethsm>`__.
-The latest image is tagged with ``testing``.
-
-.. _test-image-configuration:
-
-Configuration
-^^^^^^^^^^^^^
-
-The image can be configured with the following environment variables.
-
-+----------------------+--------------------------------------+
-| Environment variable | Description                          |
-+======================+======================================+
-| ``DEBUG_LOG``        | Enables extended logging for NetHSM. |
-+----------------------+--------------------------------------+
-
-Usage
-^^^^^
-
-The container can be executed as follows.
-
-.. tabs::
-   .. tab:: Docker
-      .. code-block:: bash
-
-         $ docker run --rm -ti -p 8443:8443 docker.io/nitrokey/nethsm:testing
-
-   .. tab:: Podman
-      .. code-block:: bash
-
-         $ podman run --rm -ti -p 8443:8443 docker.io/nitrokey/nethsm:testing
-
-This will run NetHSM as a Unix process inside the container and expose the REST API via the HTTPS protocol on port `8443`.
-
-.. important::
-   The container uses a self-signed TLS certificate.
-   Make sure to use the correct connection settings to establish a connection.
-   Please refer to chapter `NetHSM introduction <index.html>`__ to learn more.
-
 Production Image
 ----------------
 
@@ -93,8 +28,6 @@ The unikernel mode runs NetHSM as a guest in a KVM based virtual machine and pro
 This mode is only available on Linux and requires access to the ``/dev/tun`` and ``/dev/kvm`` device nodes and the ``NET_ADMIN`` capability.
 
 The mode can be set with the environment variable ``MODE`` (see next chapter `Configuration <container.html#production-image-configuration>`__).
-
-.. _production-image-configuration:
 
 Configuration
 ^^^^^^^^^^^^^

--- a/source/components/nethsm/container/production-image.rst
+++ b/source/components/nethsm/container/production-image.rst
@@ -4,6 +4,7 @@ Production Image
 The production image is provided for production envrionments with high security demands.
 It requires an external etcd key-value store and offers to run the NetHSM process with hardware-based separation (KVM).
 The connection between the NetHSM process and the key-value store is encrypted.
+Additionally, the required secrets such as certificates and private keys can be set through the secrets feature of the container executor.
 
 The NetHSM production container is a product for paying customers only and can be purchased `here <https://www.nitrokey.com/contact>`__.
 The image can be obtained from `Nitrokey NetHSM registry <https://registry.git.nitrokey.com/distribution/nethsm>`_ using the credentials provided after purchase.
@@ -36,7 +37,6 @@ Configuration
 ^^^^^^^^^^^^^
 
 The container can be configured with the following environment variables.
-Secrets should be passed in with the secrets feature of Docker or Podman.
 
 +----------------------+----------------------------------------------------------------------------------------------------+
 | Environment variable | Description                                                                                        |
@@ -57,6 +57,26 @@ Secrets should be passed in with the secrets feature of Docker or Podman.
 +----------------------+----------------------------------------------------------------------------------------------------+
 | ``ETCD_CLIENT_KEY``  | The path to the secret key for the client authentication.                                          |
 +----------------------+----------------------------------------------------------------------------------------------------+
+
+The container runtime secrets such as certificates and private keys need to be set with the secrets feature of Docker or Podman.
+
++-----------------+----------------------------------------------------------------------------------------------------------------------------------+
+| Secret variable | Description                                                                                                                      |
++=================+==================================================================================================================================+
+| ``ca_cert``     | CA certificate which signed the client certificate and server certificate.                                                       |
++-----------------+----------------------------------------------------------------------------------------------------------------------------------+
+| ``client_cert`` | Client certificate for authentication of the NetHSM process with the key-value store.                                            |
++-----------------+----------------------------------------------------------------------------------------------------------------------------------+
+| ``client_key``  | Client key for authentication of the NetHSM process with the key-value store.                                                    |
++-----------------+----------------------------------------------------------------------------------------------------------------------------------+
+| ``server_cert`` | Server certificate for the API of the key-value store.                                                                           |
++-----------------+----------------------------------------------------------------------------------------------------------------------------------+
+| ``server_key``  | Server key for the API of the key-value store.                                                                                   |
++-----------------+----------------------------------------------------------------------------------------------------------------------------------+
+| ``device_key``  | Device key of the NetHSM process. To learn more about the device key refer to chapter                                            |
+|                 | `Terminology and Conventions <https://github.com/Nitrokey/nethsm/blob/main/docs/system-design.md#terminology-and-conventions>`__ |
+|                 | in the system design.                                                                                                            |
++-----------------+----------------------------------------------------------------------------------------------------------------------------------+
 
 Usage
 ^^^^^

--- a/source/components/nethsm/container/production-image.rst
+++ b/source/components/nethsm/container/production-image.rst
@@ -1,10 +1,13 @@
 Production Image
 ----------------
 
-The production image is provided for production envrionments with high security demands.
+The production image is provided for production environments with high security demands.
+The image is distributed as OCI image and can be run locally with a compatible executor such as Docker and Podman.
 It requires an external etcd key-value store and offers to run the NetHSM process with hardware-based separation (KVM).
 The connection between the NetHSM process and the key-value store is encrypted.
 Additionally, the required secrets such as certificates and private keys can be set through the secrets feature of the container executor.
+
+.. include:: container-hardware-restriction.rst.inc
 
 The NetHSM production container is a product for paying customers only and can be purchased `here <https://www.nitrokey.com/contact>`__.
 The image can be obtained from `Nitrokey NetHSM registry <https://registry.git.nitrokey.com/distribution/nethsm>`_ using the credentials provided after purchase.

--- a/source/components/nethsm/container/production-image.rst
+++ b/source/components/nethsm/container/production-image.rst
@@ -2,10 +2,9 @@ Production Image
 ----------------
 
 The production image is provided for production environments with high security demands.
+It requires an external etcd key-value store which is connected through an encrypted connection.
+The NetHSM process can be executed with hardware-based separation (KVM) and device-specific encryption.
 The image is distributed as OCI image and can be run locally with a compatible executor such as Docker and Podman.
-It requires an external etcd key-value store and offers to run the NetHSM process with hardware-based separation (KVM).
-The connection between the NetHSM process and the key-value store is encrypted.
-Additionally, the required secrets such as certificates and private keys can be set through the secrets feature of the container executor.
 
 .. include:: container-hardware-restriction.rst.inc
 

--- a/source/components/nethsm/container/production-image.rst
+++ b/source/components/nethsm/container/production-image.rst
@@ -31,6 +31,10 @@ The Unix process mode runs NetHSM as a process on top of the operating system.
 The unikernel mode runs NetHSM as a guest in a KVM based virtual machine and provides strong separation from the host operating system.
 This mode is only available on Linux and requires access to the ``/dev/tun`` and ``/dev/kvm`` device nodes and the ``NET_ADMIN`` capability.
 
+.. important::
+
+   For security choose to run the container in the unikernel mode.
+
 The mode can be set with the environment variable ``MODE`` (see next chapter `Configuration <container.html#production-image-configuration>`__).
 
 Configuration

--- a/source/components/nethsm/container/test-image.rst
+++ b/source/components/nethsm/container/test-image.rst
@@ -1,0 +1,48 @@
+Test Image
+----------
+
+The image can be obtained from `Docker Hub <https://hub.docker.com/r/nitrokey/nethsm>`_.
+
+.. warning::
+
+   Do not use the test image under any circumstances for production data and use cases.
+
+Tagging Policy
+^^^^^^^^^^^^^^
+
+The images in the repository are tagged with the Git commit hash from the main branch of the `repository <https://github.com/nitrokey/nethsm>`__.
+The latest image is tagged with ``testing``.
+
+Configuration
+^^^^^^^^^^^^^
+
+The image can be configured with the following environment variables.
+
++----------------------+--------------------------------------+
+| Environment variable | Description                          |
++======================+======================================+
+| ``DEBUG_LOG``        | Enables extended logging for NetHSM. |
++----------------------+--------------------------------------+
+
+Usage
+^^^^^
+
+The container can be executed as follows.
+
+.. tabs::
+   .. tab:: Docker
+      .. code-block:: bash
+
+         $ docker run --rm -ti -p 8443:8443 docker.io/nitrokey/nethsm:testing
+
+   .. tab:: Podman
+      .. code-block:: bash
+
+         $ podman run --rm -ti -p 8443:8443 docker.io/nitrokey/nethsm:testing
+
+This will run NetHSM as a Unix process inside the container and expose the REST API via the HTTPS protocol on port `8443`.
+
+.. important::
+   The container uses a self-signed TLS certificate.
+   Make sure to use the correct connection settings to establish a connection.
+   Please refer to chapter `NetHSM introduction <index.html>`__ to learn more.

--- a/source/components/nethsm/container/test-image.rst
+++ b/source/components/nethsm/container/test-image.rst
@@ -2,8 +2,11 @@ Test Image
 ----------
 
 The test image is provided for testing and development purposes.
+The image is distributed as OCI image and can be run locally with a compatible executor such as Docker and Podman.
 It does not offer to run the NetHSM process with hardware-based separation (KVM).
 The connection between the NetHSM process and the integrated key-value store is unencrypted.
+
+.. include:: container-hardware-restriction.rst.inc
 
 The image can be obtained from `Docker Hub <https://hub.docker.com/r/nitrokey/nethsm>`_.
 

--- a/source/components/nethsm/container/test-image.rst
+++ b/source/components/nethsm/container/test-image.rst
@@ -2,9 +2,9 @@ Test Image
 ----------
 
 The test image is provided for testing and development purposes.
-The image is distributed as OCI image and can be run locally with a compatible executor such as Docker and Podman.
-It does not offer to run the NetHSM process with hardware-based separation (KVM).
+It does not offer to run the NetHSM process with hardware-based separation (KVM), to encrypt the data store, or to use an external etcd.
 The connection between the NetHSM process and the integrated key-value store is unencrypted.
+The image is distributed as OCI image and can be run locally with a compatible executor such as Docker and Podman.
 
 .. include:: container-hardware-restriction.rst.inc
 

--- a/source/components/nethsm/container/test-image.rst
+++ b/source/components/nethsm/container/test-image.rst
@@ -1,11 +1,16 @@
 Test Image
 ----------
 
+The test image is provided for testing and development purposes.
+It does not offer to run the NetHSM process with hardware-based separation (KVM).
+The connection between the NetHSM process and the integrated key-value store is unencrypted.
+
 The image can be obtained from `Docker Hub <https://hub.docker.com/r/nitrokey/nethsm>`_.
 
 .. warning::
 
    Do not use the test image under any circumstances for production data and use cases.
+   For production environments with high security demands you must use the production image.
 
 Tagging Policy
 ^^^^^^^^^^^^^^

--- a/source/components/nethsm/index.rst
+++ b/source/components/nethsm/index.rst
@@ -47,3 +47,4 @@ In case you want to restore a backup of a NetHSM, please refer to the chapter `R
    opendnssec.rst
    ejbca.rst
    knotdns.rst
+   container.rst

--- a/source/components/nethsm/index.rst
+++ b/source/components/nethsm/index.rst
@@ -47,4 +47,4 @@ In case you want to restore a backup of a NetHSM, please refer to the chapter `R
    opendnssec.rst
    ejbca.rst
    knotdns.rst
-   container.rst
+   container/index.rst

--- a/source/components/nethsm/integration.rst
+++ b/source/components/nethsm/integration.rst
@@ -30,48 +30,8 @@ It will be reset every eight hours (CET 6:00, 14:00, 22:00). User "admin", passw
 Container Image
 ^^^^^^^^^^^^^^^
 
-The container image is distributed as an OCI image and can be obtained from `Docker Hub <https://hub.docker.com/r/nitrokey/nethsm>`_.
-It can be run locally with a compatible executor, e.g. Docker or Podman.
-
-Compared to the NetHSM hardware the following functions are not implemented at software container's REST API:
-
-* network configuration
-* factory reset
-* reboot
-* software update
-
-The container can be executed as follows.
-
-.. tabs::
-   .. tab:: Docker
-      .. code-block:: bash
-
-         $ sudo docker run --rm -ti -p8443:8443 nitrokey/nethsm:testing
-
-   .. tab:: Podman
-      .. code-block:: bash
-
-         $ podman run --rm -ti -p8443:8443 docker.io/nitrokey/nethsm:testing 
-
-This will run NetHSM as a Unix process inside the container and expose the REST API on the port `8443` via the HTTPS protocol.
-
-Additionaly to running the NetHSM as a Unix process it can be run as a unikernel supported by KVM.
-
-The container can be executed as follows.
-
-.. tabs::
-   .. tab:: Docker
-      .. code-block:: bash
-
-         $ docker run -ti --rm -p 8443:8443 --device /dev/net/tun --device /dev/kvm --cap-add=NET_ADMIN nitrokey/nethsm:testing
-
-This will run NetHSM as a unikernel inside a KVM virtual machine.
-The container will expose the REST API, via the HTTPS protocol, on the interface `tap200` with the IP address `192.168.1.100` and port `8443`.
-
-.. important::
-   The container uses a self-signed TLS certificate.
-   Make sure to use the correct connection settings to establish a connection.
-   Please refer to chapter `NetHSM introduction <index.html>`__ to learn more.
+For the NetHSM two container images are available for testing and production.
+Please refer to the chapter `Container <nethsm/container.html>`__ to learn more about the options.
 
 Integration Into Custom Application
 -----------------------------------

--- a/source/components/nethsm/integration.rst
+++ b/source/components/nethsm/integration.rst
@@ -30,8 +30,7 @@ It will be reset every eight hours (CET 6:00, 14:00, 22:00). User "admin", passw
 Container Image
 ^^^^^^^^^^^^^^^
 
-For the NetHSM two container images are available for testing and production.
-Please refer to the chapter `Container <nethsm/container.html>`__ to learn more about the options.
+NetHSM `container images <nethsm/container.html>`__ are available for testing and production.
 
 Integration Into Custom Application
 -----------------------------------

--- a/source/components/nethsm/integration.rst
+++ b/source/components/nethsm/integration.rst
@@ -30,7 +30,7 @@ It will be reset every eight hours (CET 6:00, 14:00, 22:00). User "admin", passw
 Container Image
 ^^^^^^^^^^^^^^^
 
-NetHSM `container images <nethsm/container.html>`__ are available for testing and production.
+NetHSM `container images <container/index.html>`__ are available for testing and production.
 
 Integration Into Custom Application
 -----------------------------------


### PR DESCRIPTION
This PR adds the documentation for the NetHSM test and production container.

Detail changes:

- New container menu under NetHSM with dedicated pages for each image.
- Explanation about differences between the images.
- Information about tagging policy and configuration for each image.
- Examples of how to run them.

Rebase of #295 