### PR TITLE
ci: Use make venv to install dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install additional python packages
-        run: pip3 install -r requirements.txt
+      - name: Create virtual environment
+        run: make venv
           
       - name: Quick build docs
         run: |
           mkdir -p dist/en
           mkdir -p build/en/doctrees
-          sphinx-build -j auto -b html -D language=en -d build/en/doctrees source dist/en
+          venv/bin/sphinx-build -j auto -b html -D language=en -d build/en/doctrees source dist/en
           rm -rf dist/en/_sources
 
       - name: Upload quick build artifact 
@@ -62,13 +62,13 @@ jobs:
           path: data.git
      
       - name: Build pot files
-        run: sphinx-build -b gettext source data.git/locales/
+        run: venv/bin/sphinx-build -b gettext source data.git/locales/
 
       - name: Build po files from pot files
         shell: bash
         run: |
           lang=($OTHER_LANGS)
-          sphinx-intl update -p data.git/locales/ ${lang[@]/*/'-l '&' '}
+          venv/bin/sphinx-intl update -p data.git/locales/ ${lang[@]/*/'-l '&' '}
           rm -rf data.git/locales/.doctrees 
 
       # this one looks like a upstream bug for the auto-translation 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,13 @@ jobs:
   syntax-check:
     name: Check syntax
     runs-on: ubuntu-latest
-    container: python:3.11-slim
+    container: python:3.11
     continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Create virtual environment
-        run: |
-          python -m venv venv
-          venv/bin/pip3 install -r requirements.txt
+        run: make venv
       - name: Syntax check
         run: |
           . venv/bin/activate
@@ -23,14 +21,12 @@ jobs:
   build-error-check:
     name: Check build error
     runs-on: ubuntu-latest
-    container: python:3.11-slim
+    container: python:3.11
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Create virtual environment
-        run: |
-          python -m venv venv
-          venv/bin/pip3 install -r requirements.txt
+        run: make venv
       - name: Build documentation
         run: |
           . venv/bin/activate


### PR DESCRIPTION
To avoid repeating the same commands in multiple locations, this patch changes the CI workflows to use `make venv` to install the Python requirements.