### PR TITLE
Update Automatic Screen Lock

### DIFF
--- a/source/components/nitrokeys/features/misc/automatic-screen-lock.rst
+++ b/source/components/nitrokeys/features/misc/automatic-screen-lock.rst
@@ -16,7 +16,7 @@ Automatic Screen Lock at Removal
      - `Nitrokey Start <https://docs.nitrokey.com/nitrokeys/start/index.html>`_
      - `Nitrokey Storage 2 <https://docs.nitrokey.com/nitrokeys/storage/index.html>`_
 
-   * - ⨯
+   * - ✓
      - ⨯
      - ⨯
      - ⨯
@@ -38,7 +38,7 @@ Requirements
 -  Ubuntu 20.04 or Debian 10 (Buster), both with `Gnome Display
    Manager <https://wiki.gnome.org/Projects/GDM>`__ installed.
 
--  Nitrokey Pro 2, Nitrokey Storage 2, or Nitrokey HSM 2
+-  Nitrokey 3, Nitrokey Pro 2, Nitrokey Storage 2, or Nitrokey HSM 2
 
 Configuration
 ~~~~~~~~~~~~~
@@ -56,7 +56,7 @@ Add the following line to the file
 
 .. code-block:: bash
 
-   ACTION=="remove", ENV{PRODUCT}=="20a0/4108/101" RUN+="/usr/local/bin/gnome-screensaver-lock"
+   ACTION=="remove", ENV{PRODUCT}=="20a0/4108/101" RUN+="/bin/bash -c '/usr/local/bin/gnome-screensaver-lock'"
 
 Save the file and quit the editor.
 
@@ -64,6 +64,7 @@ This file sets up a new hardware rule that executes the ``gnome-screensaver-lock
 
 You should change the configuration according to the device you are using as following:
 
+-  Nitrokey 3: ``ENV{PRODUCT}=="20a0/42b2/107"``
 -  Nitrokey Pro: ``ENV{PRODUCT}=="20a0/4108/101"``
 -  Nitrokey HSM: ``ENV{PRODUCT}=="20a0/4230/101"``
 -  Nitrokey Storage: ``ENV{PRODUCT}=="20a0/4109/101"``
@@ -87,10 +88,10 @@ Add the following text
 
 .. code-block:: bash
 
-   user=`ps axo user:30,comm | egrep "gdm-(wayland|x)" | awk '{print $1}'`
+   user=`ps axo user:30,comm | grep -E "gdm-(wayland|x)" | awk '{print $1}'`
 
    if [ -n $user ]; then
-           su $user -c "/usr/bin/dbus-send --type=method_call --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock"
+           su $user -c "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus /usr/bin/dbus-send --type=method_call --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock"
    fi
 
 In the first step, this script looks for the user-name of the gnome session, i.e. ``user``.


### PR DESCRIPTION
I updated instructions how to do automatic screen lock with Nitrokey 3A Mini on Arch Linux.

Add Nitrokey 3 support.
Replace `egrep` with `grep -E`, because egrep is obsolescent.
Run bash script in bash, otherwise it would not work for me.
Add `DBUS_SESSION_BUS_ADDRESS` env variable, otherwise it would not work for me.