### PR TITLE
ci: add sphinx-intl (.po) locales path; precise commit msg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         shell: bash
         run: |
           lang=($OTHER_LANGS)
-          venv/bin/sphinx-intl update -p data.git/locales/ ${lang[@]/*/'-l '&' '}
+          venv/bin/sphinx-intl update -p data.git/locales/ -d data.git/locales/ ${lang[@]/*/'-l '&' '}
           rm -rf data.git/locales/.doctrees 
 
       # this one looks like a upstream bug for the auto-translation 
@@ -88,6 +88,6 @@ jobs:
           git config --global --add safe.directory $(pwd)
           git config --global user.name "GitHub Action"
           git config --global user.email "gh-action@noreply.gh.com"
-          if (git commit -m "Automated .pot generation" locales); then
+          if (git commit -m "Automated .pot/.po generation" locales); then
             git push          
           fi


### PR DESCRIPTION
* The output for `sphinx-intl` (.po files) was not explicitly set to the `data.git/locales` directory, added `-d`
* the commit message into the `-data` repo was not clear towards what is commited... improved
