### PR TITLE
Ensure all links to udev rules file point to recent version

### DIFF
--- a/source/components/nitrokeys/features/fido2/website.rst
+++ b/source/components/nitrokeys/features/fido2/website.rst
@@ -168,7 +168,7 @@ Troubleshooting (Linux)
 
 -  If the Nitrokey is not accepted immediately, you may need to copy
    this file
-   `41-nitrokey.rules <https://www.nitrokey.com/sites/default/files/41-nitrokey.rules>`__
+   `41-nitrokey.rules <https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules>`__
    to ``etc/udev/rules.d/``. In very rare cases, the system will need
    the `older
    version <https://raw.githubusercontent.com/Nitrokey/libnitrokey/master/data/41-nitrokey_old.rules>`__

--- a/source/components/nitrokeys/features/u2f/2fa.rst
+++ b/source/components/nitrokeys/features/u2f/2fa.rst
@@ -24,7 +24,7 @@ Troubleshooting (Linux)
 
 -  If the Nitrokey is not accepted immediately, you may need to copy
    this file
-   `41-nitrokey.rules <https://www.nitrokey.com/sites/default/files/41-nitrokey.rules>`__
+   `41-nitrokey.rules <https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules>`__
    to ``etc/udev/rules.d/``. In very rare cases, the system will need
    the `older
    version <https://raw.githubusercontent.com/Nitrokey/libnitrokey/master/data/41-nitrokey_old.rules>`__

--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -90,7 +90,7 @@ CLI Method
    .. code-block:: bash
 
       $ cd /etc/udev/rules.d/
-      $ sudo wget https://raw.githubusercontent.com/Nitrokey/libnitrokey/master/data/41-nitrokey.rules
+      $ sudo wget https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules
 
    And restart ``udev`` service
 

--- a/source/components/nitrokeys/fido2/getting-started.rst
+++ b/source/components/nitrokeys/fido2/getting-started.rst
@@ -182,7 +182,7 @@ Troubleshooting (Linux)
 If the Nitrokey is not detected, proceed the following:
 
 1. Copy this file
-   `41-nitrokey.rules <https://www.nitrokey.com/sites/default/files/41-nitrokey.rules>`__
+   `41-nitrokey.rules <https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules>`__
    to ``/etc/udev/rules.d/``. In very rare cases, the system will need
    the `older
    version <https://raw.githubusercontent.com/Nitrokey/libnitrokey/master/data/41-nitrokey_old.rules>`__

--- a/source/components/nitrokeys/nitrokey3/firmware-update.rst
+++ b/source/components/nitrokeys/nitrokey3/firmware-update.rst
@@ -101,4 +101,4 @@ Troubleshooting (Linux):
   your machine. Afterwards the update should work without the 
   permission issue.
 
-.. _udev-rules: https://raw.githubusercontent.com/Nitrokey/libnitrokey/master/data/41-nitrokey.rules
+.. _udev-rules: https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules

--- a/source/components/nitrokeys/nitrokey3/troubleshooting.rst
+++ b/source/components/nitrokeys/nitrokey3/troubleshooting.rst
@@ -10,7 +10,7 @@ Nitrokey is Not Detected on Linux
 If the Nitrokey is not detected, proceed as follows:
 
 1. Copy this file
-   `41-nitrokey.rules <https://www.nitrokey.com/sites/default/files/41-nitrokey.rules>`__
+   `41-nitrokey.rules <https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules>`__
    to ``/etc/udev/rules.d/``.
 2. Restart udev via ``sudo service udev restart`` or ``udevadm control --reload-rules && udevadm trigger`` if you are using Fedora.
 

--- a/source/components/nitrokeys/pro/firmware-update.rst
+++ b/source/components/nitrokeys/pro/firmware-update.rst
@@ -93,4 +93,4 @@ Linux Permission error
   your machine. Afterwards the update should work without the 
   permission issue.
 
-.. _udev-rules: https://raw.githubusercontent.com/Nitrokey/libnitrokey/master/data/41-nitrokey.rules
+.. _udev-rules: https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules

--- a/source/components/nitrokeys/start/getting-started.rst
+++ b/source/components/nitrokeys/start/getting-started.rst
@@ -79,5 +79,5 @@ the UDEV rules:
 
 .. code-block:: bash
 
-   wget https://raw.githubusercontent.com/Nitrokey/libnitrokey/master/data/41-nitrokey.rules
+   wget https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules
    sudo mv 41-nitrokey.rules /etc/udev/rules.d/


### PR DESCRIPTION
The udev rules file `41-nitrokey.rules` is crucial to the devices' functioning under Linux.  The canonical and maintained version of these rules seems to be the one at https://github.com/Nitrokey/nitrokey-udev-rules

The documentation contained several links to older, unmaintained versions at different URLs, which are missing some recent fixes, e.g. [nitrokey-udev-rules PR #6](https://github.com/Nitrokey/nitrokey-udev-rules/pull/6).

Make sure the documentation always links to the maintained version at https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules

The old URLs that have been replaced where:
https://raw.githubusercontent.com/Nitrokey/libnitrokey/master/data/41-nitrokey.rules
https://www.nitrokey.com/sites/default/files/41-nitrokey.rules

Now all URLs point to either https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules or https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/refs/heads/main/41-nitrokey.rules, which both lead to the same file/version.
