### PR TITLE
Update openpgp-keygen-backup.rst

### DIFF
--- a/source/components/nitrokeys/features/openpgp-card/openpgp-keygen-backup.rst
+++ b/source/components/nitrokeys/features/openpgp-card/openpgp-keygen-backup.rst
@@ -204,6 +204,18 @@ Now is good time to backup your key. Please keep this backup very secure. It is 
 
    > gpg --export-secret-keys jane@example.com > sec-key.asc
 
+Optionally user can chose to export an 'encrypted backup' of the secret key ,to avoid accidental leakage of secret key (This is not a full-proof method or replacement for offline computers but should still provide good security against leakeges)
+
+.. code-block:: bash
+
+   > gpg --export-secret-keys --armor jane@example.com | gpg --symmetric --cipher-algo AES256 -o sec-key.gpg
+
+On linux following command can be used to secure wipe and delete the unencrypted backup of key from the disk.
+
+.. code-block:: bash
+
+   > shred -u sec-key.asc
+
 Key Import
 ----------
 

--- a/source/components/nitrokeys/features/openpgp-card/openpgp-keygen-backup.rst
+++ b/source/components/nitrokeys/features/openpgp-card/openpgp-keygen-backup.rst
@@ -210,6 +210,8 @@ Optionally user can chose to export an 'encrypted backup' of the secret key ,to 
 
    > gpg --export-secret-keys --armor jane@example.com | gpg --symmetric --cipher-algo AES256 -o sec-key.gpg
 
+A passphrase prompt will be shown to you on running the above command. You must need to keep this passphrase safely for successful decryption of your private key.
+
 On linux following command can be used to secure wipe and delete the unencrypted backup of key from the disk.
 
 .. code-block:: bash


### PR DESCRIPTION
Added a command for optionally exporting a encrypted backups of the private keys , rather than a plain text one. This step should provide better security in backup storage. Also added shred command for secure deletion of backed up key.
Refer comments in #416 