### PR TITLE
Installation on Debian needs more dependencies

### DIFF
--- a/source/components/software/nitropy/all-platforms/installation.rst
+++ b/source/components/software/nitropy/all-platforms/installation.rst
@@ -14,7 +14,7 @@ Ubuntu, Debian
 ~~~~~~~~~~~~~~
 You can install nitropy along with all other required dependencies by using::
 
-    $ sudo apt install pipx && pipx ensurepath && pipx install pynitrokey
+    $ sudo apt install pipx libpython3-dev libudev-dev && pipx ensurepath && pipx install pynitrokey
 
 After logging out or restarting your system, nitropy will now be available.
 


### PR DESCRIPTION
Maybe even more. But I'm not able to reset the pipx dependency cache. Not even by `apt remove pipx`.