### PR TITLE
usbguard add

### DIFF
--- a/source/components/nitrokeys/nitrokey3/index.rst
+++ b/source/components/nitrokeys/nitrokey3/index.rst
@@ -25,6 +25,7 @@ and the product guides:
     nitropy <nitropy>
     Reset <reset>
     Troubleshooting <troubleshooting>
+    USBGuard <usbguard>
 
 or check out the features:
 

--- a/source/components/nitrokeys/nitrokey3/usbguard.rst
+++ b/source/components/nitrokeys/nitrokey3/usbguard.rst
@@ -7,13 +7,13 @@ Especially thunderbolt (which can be blocked globally, see `this config as to ho
 
 1. Install USBGuard
 
-Debian/Ubuntu or Linux mint:
+    Debian/Ubuntu or Linux mint:
 
-``sudo apt install usbguard usbutils udisks2 usbguard-notifier``
+    ``sudo apt install usbguard usbutils udisks2 usbguard-notifier``
 
-Fedora:
+    Fedora:
 
-``sudo dnf install -y usbguard usbguard-notifier usbguard-selinux ``
+    ``sudo dnf install -y usbguard usbguard-notifier usbguard-selinux ``
 
 2. Set it up
 

--- a/source/components/nitrokeys/nitrokey3/usbguard.rst
+++ b/source/components/nitrokeys/nitrokey3/usbguard.rst
@@ -13,7 +13,7 @@ Especially thunderbolt (which can be blocked globally, see `this config as to ho
 
     Fedora:
 
-    ``sudo dnf install -y usbguard usbguard-notifier usbguard-selinux ``
+    ``sudo dnf install -y usbguard usbguard-notifier usbguard-selinux``
 
 2. Set it up
 

--- a/source/components/nitrokeys/nitrokey3/usbguard.rst
+++ b/source/components/nitrokeys/nitrokey3/usbguard.rst
@@ -1,0 +1,35 @@
+USBGuard
+========
+
+Using usbguard is pretty essential to protect against common attacks like malicious devices, rubber duckies, OMG cables or the “governmental 3 letter agency equivalents”.
+
+Especially thunderbolt (which can be blocked globally, see `this config as to how <https://github.com/secureblue/secureblue/tree/live/files/system/etc/modprobe.d>`__ can grant attackers access to your RAM, which means encryption keys and more.
+
+1. Install USBGuard
+
+Debian/Ubuntu or Linux mint:
+
+``sudo apt install usbguard usbutils udisks2 usbguard-notifier``
+
+Fedora:
+
+``sudo dnf install -y usbguard usbguard-notifier usbguard-selinux ``
+
+2. Set it up
+
+Make sure to have your keyboard and mouse plugged in. 
+
+These commands will permanently allow all currently connected devices:
+
+.. code-block:: bash
+
+    pkexec sh -c '
+            mkdir -p /var/log/usbguard
+            mkdir -p /etc/usbguard
+            chmod 755 /etc/usbguard
+            usbguard generate-policy > /etc/usbguard/rules.conf
+            systemctl enable --now usbguard.service
+            usbguard add-user $1
+        ' -- $ACTIVE_USERNAME
+        systemctl enable --user --now usbguard-notifier.service
+


### PR DESCRIPTION
I did test the install commands on QubesOS with Debian & Fedora qube which worked and also the setup (part 2).

As a result I after installing and do the set up (2.) I can't attach any USB devices to the qube. Which mean that that install worked.

But I cannot test any further since USBGuard and QubesOS are not meant to be used together (maybe add a disclaimer about this?)

Need to be tested on a proper system.

And also in the first sentence we also should remove the “governmental 3 letter agency equivalents".

I did not included the part 3 & 4 from the forum post I don't think this is relevant.