### PR TITLE
Revert "structure fix"

### DIFF
--- a/source/components/nitrokeys/features/openpgp-card/index.rst
+++ b/source/components/nitrokeys/features/openpgp-card/index.rst
@@ -21,7 +21,7 @@ OpenPGP Card
 	Desktop Login <desktop-login/index>
 	SSH <ssh/index>
 	IPSec <ipsec>
-	Hard Disk Encryption <hard-disk-encryption>
+	Hard Disk Encryption <hard-disk-encryption/index>
 	Stunnel <stunnel>
 	Gnu Privacy Assistant (GPA) <gpa>
 	EID <eid>


### PR DESCRIPTION
Reverts Nitrokey/nitrokey-documentation#442

This was a wrong commit