### PR TITLE
Add note about USB ports and USB drive compatibility

### DIFF
--- a/source/components/nethsm/system_recovery.rst
+++ b/source/components/nethsm/system_recovery.rst
@@ -36,11 +36,10 @@ The system recovery can be performed as follows.
       3. Write the installer image to a USB flash drive.
          For this you could use the graphical tool `balenaEtcher <https://etcher.balena.io/>`__. On Linux you could also use the command line tool `dd`.
          Ignore any warning that a partition table is missing.
-      4. Connect the USB flash drive with a USB port of the NetHSM.
-         The NetHSM can boot from any USB-A port of the machine.
+      4. Connect the USB flash drive with any USB port of the NetHSM.
 
          .. important::
-            Some USB drives are incompatible with the firmware of the NetHSM.
+            Some USB drives are incompatible with the NetHSM.
             This results in the NetHSM not recognizing them as a boot media.
             In case the NetHSM does not boot from the connected USB drive, try a different USB drive model.
 

--- a/source/components/nethsm/system_recovery.rst
+++ b/source/components/nethsm/system_recovery.rst
@@ -36,7 +36,14 @@ The system recovery can be performed as follows.
       3. Write the installer image to a USB flash drive.
          For this you could use the graphical tool `balenaEtcher <https://etcher.balena.io/>`__. On Linux you could also use the command line tool `dd`.
          Ignore any warning that a partition table is missing.
-      4. Connect the USB flash drive with a USB port at the front panel of the NetHSM.
+      4. Connect the USB flash drive with a USB port of the NetHSM.
+         The NetHSM can boot from any USB-A port of the machine.
+
+         .. important::
+            Some USB drives are incompatible with the firmware of the NetHSM.
+            This results in the NetHSM not recognizing them as a boot media.
+            In case the NetHSM does not boot from the connected USB drive, try a different USB drive model.
+
       5. Optionally: Connect a keyboard and monitor with the NetHSM.
       6. Make sure the system is turned off, but connected to power.
       7. Turn the NetHSM on by pressing the power button on the front.


### PR DESCRIPTION
This PR makes clear that all USB-A ports on the NetHSM can be used for booting from a USB drive and also adds a note about handling of incompatible USB drives.