### PR TITLE
Adds required Fedora developer packages to nitropy installation

### DIFF
--- a/source/components/software/nitropy/all-platforms/installation.rst
+++ b/source/components/software/nitropy/all-platforms/installation.rst
@@ -41,7 +41,7 @@ If you have already installed Python on your system, you can simply run::
 
     $ sudo dnf install pipx python3-devel libudev-devel && pipx ensurepath && pipx install pynitrokey
 
-After logging our or restarting your system, nitropy will now be available.
+After logging out or restarting your system, nitropy will now be available.
 
 Mageia
 ~~~~~~

--- a/source/components/software/nitropy/all-platforms/installation.rst
+++ b/source/components/software/nitropy/all-platforms/installation.rst
@@ -35,11 +35,11 @@ Fedora
 
 You can install nitropy along with all other required dependencies by using::
 
-    $ sudo dnf install python pipx && pipx ensurepath && pipx install pynitrokey
+    $ sudo dnf install python pipx python3-devel libudev-devel && pipx ensurepath && pipx install pynitrokey
 
 If you have already installed Python on your system, you can simply run::
 
-    $ sudo dnf install pipx && pipx ensurepath && pipx install pynitrokey
+    $ sudo dnf install pipx python3-devel libudev-devel && pipx ensurepath && pipx install pynitrokey
 
 After logging our or restarting your system, nitropy will now be available.
 


### PR DESCRIPTION
As described in #457, there are a couple of issues with the nitropy installation process on Fedora.

I've added a couple of packages to the installation commands which fixed my issues.