### PR TITLE
NK3 PIV documentation fix

### DIFF
--- a/source/components/nitrokeys/nitrokey3/set-pins.rst
+++ b/source/components/nitrokeys/nitrokey3/set-pins.rst
@@ -191,7 +191,7 @@ PUK
 ^^^
 
 The *PUK* is used for management operations, such as unblocking the PIN.
-The factory default for the *PUK* is ``123456``.
+The factory default for the *PUK* is ``12345678``.
 
 .. note::
     The *PUK* must have a maximal length of 8 characters.


### PR DESCRIPTION
Current documentation specifies PUK as `123456`, while it's actually 8 characters `12345678` https://github.com/trussed-dev/piv-authenticator/blob/b3ed091f12238c35174973bcb82fa99b4d9f2e63/tests/command_response.rs#L251.