### PR TITLE
Adds workaround for recognition of CCID library for HSM 2 on macOS

### DIFF
--- a/source/components/nitrokeys/hsm/getting-started.rst
+++ b/source/components/nitrokeys/hsm/getting-started.rst
@@ -15,11 +15,16 @@ Getting Started
             `this <https://www.cardcontact.de/download/sc-hsm-starterkit.zip>`__
             driver (`source <https://github.com/CardContact/sc-hsm-embedded>`__).
 
-        .. tab:: MacOS
+        .. tab:: macOS
             Install `OpenSC <https://github.com/OpenSC/OpenSC/wiki>`__.
             Alternatively, install
             `this <https://www.cardcontact.de/download/sc-hsm-starterkit.zip>`__
             driver (`source <https://github.com/CardContact/sc-hsm-embedded>`__).
+
+            On some macOS versions, OpenSC fails to find the CCID library of the operating system.
+            In this case OpenSC tools will show ``Unresponsive Card`` errors.
+            The problem can be fixed by either copying or symlinking the directory ``/usr/libexec/SmartCardServices`` to ``/usr/local/libexec/SmartCardServices``.
+            A reboot after this change is mandatory to make the new library to be recognized.
 
         .. tab:: Windows
             Install `OpenSC <https://github.com/OpenSC/OpenSC/wiki>`__.


### PR DESCRIPTION
This PR adds a workaround for HSM 2 on macOS with OpenSC.

On some versions of macOS (tested on macOS 15.5, but user reports indicate that also past versions are concerned), the CCID library `libccid.dylib` of macOS isn't recognized by OpenSC resulting in a `Card Unresponsive` error. This error concerns OpenSC installed from the GitHub releases as well as the release on Homebrew.