### PR TITLE
Add check for hyperlinks to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,17 @@ jobs:
         run: make venv
       - name: Syntax check
         run: make check-syntax
-
+  check-hyperlinks:
+    name: Check hyperlinks
+    runs-on: ubuntu-latest
+    container: python:3.11
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Create virtual environment
+        run: make venv
+      - name: Check hyperlinks
+        run: make check-hyperlinks
   build-check-and-preview-upload:
     name: Check Build and Upload to Preview
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ check-syntax: venv
 		--ignore-messages "faq(.*)Hyperlink target(.*)is not referenced" \
 		source
 
+.PHONY: check-hyperlinks
+check-hyperlinks: venv docs
+	venv/bin/linkchecker -f linkcheckerrc dist/en/index.html
+
 .PHONY: pkg
 pkg: venv docs
 	mv dist/en/_images dist/_images

--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -1,0 +1,6 @@
+[filtering]
+ignore="/(de|fr|es|nl|it|ja|ru|el|da|bg|et|fi|lv|lt|pl|pt|ro|sv|sk|sl|cs|hu|zh_CN)"
+
+[output]
+warnings=1
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ urllib3==2.2.3
 setuptools==75.6.0
 docutils==0.21.2
 sphinx-design==0.6.1
+LinkChecker==10.5.0


### PR DESCRIPTION
This PR adds a job to the CI pipeline that checks for broken hyperlinks in the documentation.

The checks give hard errors and warnings. Some errors are partly mitigated in the deployed version by the web server, which appends the respective file type. Hyperlinks to external sites are currently not checked.