### PR TITLE
Fix broken hyperlinks pointing to out own documentation

### DIFF
--- a/source/components/nethsm/administration.rst
+++ b/source/components/nethsm/administration.rst
@@ -2,7 +2,7 @@ Administration
 ==============
 
 This chapter describes administrative tasks for users with the *Administrator* role.
-Please refer to chapter `Roles <administration#roles>`__ to learn more about the role.
+Please refer to chapter `Roles <administration.html#roles>`__ to learn more about the role.
 
 .. important::
    Please make sure you read the information in the beginning of `this document <index.html>`__ before starting to work.
@@ -142,7 +142,7 @@ The current state of the NetHSM can be retrieved as follows.
       Information about the `/health/state` endpoint can be found in the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html#/default/GET_health-state>`__.
 
 A new NetHSM has an *Unprovisioned* state and after provisioning enters the *Operational* state.
-The provisioning of a NetHSM is described in the chapter `Provisioning <getting-started#provisioning>`__.
+The provisioning of a NetHSM is described in the chapter `Provisioning <getting-started.html#provisioning>`__.
 
 A NetHSM in *Operational* state can be locked again to protect it as follows.
 
@@ -493,7 +493,7 @@ Metrics
 ~~~~~~~
 
 The NetHSM logs metrics of system parameters.
-Please refer to `Metrics <metrics>`__ to learn more about each metric.
+Please refer to `Metrics <metrics.html>`__ to learn more about each metric.
 
 The metrics can be retrieved as follows.
 
@@ -624,7 +624,7 @@ The syslog server configuration can be set as follows.
 
 The serial console works right from the start of the NetHSM hardware. It includes events from the NetHSM firmware and the NetHSM software. The serial console is typically only necessary when debugging issues for which the syslog does not provide sufficient information.
 
-The location of the serial port depends on the model of the device. Please refer to the chapter `Getting started <getting-started>`__ to locate the port on your model.
+The location of the serial port depends on the model of the device. Please refer to the chapter `Getting started <getting-started.html>`__ to locate the port on your model.
 
 The serial console port differences of each model are as follows.
 
@@ -678,7 +678,7 @@ namely *Configuration Store*, *Authentication Store*, *Domain Key Store* and *Ke
 
 .. important::
    A NetHSM system software in *Unattended Boot* mode will require the *Unlock Passphrase* if restored on a different NetHSM hardware.
-   Please refer to chapter `Unlock Passphrase <administration#unlock-passphrase>`__ to learn more.
+   Please refer to chapter `Unlock Passphrase <administration.html#unlock-passphrase>`__ to learn more.
 
 .. important::
    A NetHSM in *Unattended Boot* mode will be in the same mode after a restore.
@@ -816,7 +816,7 @@ Software updates can be installed in a two-step process. First the update image 
 
 .. warning::
 
-   Ensure you install the correct update file for your hardware model NetHSM 1 or NetHSM 2. You can check your model in the `system information <administration#system-information>`__.
+   Ensure you install the correct update file for your hardware model NetHSM 1 or NetHSM 2. You can check your model in the `system information <administration.html#system-information>`__.
 
 The update file can be uploaded as follows.
 
@@ -849,7 +849,7 @@ Afterwards the update can be applied or aborted. Please refer to the desired opt
    If the upload of the update image fails with ``Error: NetHSM request failed: Bad request -- malformed image``, please follow the steps below.
 
    1. Make sure you have a valid update file by checking with the provided signature.
-   2. Make sure you don't have a high log level, such as ``DEBUG`` enabled. Please refer to chapter `Logging <https://docs.nitrokey.com/nethsm/administration#logging>`__ to learn more about the log level configuration.
+   2. Make sure you don't have a high log level, such as ``DEBUG`` enabled. Please refer to chapter `Logging <https://docs.nitrokey.com/nethsm/administration.html#logging>`__ to learn more about the log level configuration.
    3. Reboot the appliance to free up used memory.
 
 The update can be applied (committed) as follows. Any data migration is only performed *after* the NetHSM has successfully booted the new system software version.
@@ -959,7 +959,7 @@ The remote shutdown can be initiated as follows.
 Reset to Factory Defaults
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A *Provisioned* NetHSM can be reset to factory defaults. In this case all user data is securely deleted and the NetHSM boots into an *Unprovisioned* state. Afterwards, you may want to `provision <getting-started#provisioning>`__ the NetHSM.
+A *Provisioned* NetHSM can be reset to factory defaults. In this case all user data is securely deleted and the NetHSM boots into an *Unprovisioned* state. Afterwards, you may want to `provision <getting-started.html#provisioning>`__ the NetHSM.
 
 The reset to factory defaults can be performed as follows.
 
@@ -1008,7 +1008,7 @@ Each user account configured on the NetHSM has one of the following *Roles* assi
 |                 | required to initiate a system backup only.                  |
 +-----------------+-------------------------------------------------------------+
 
-See `Namespaces <administration#namespaces>`__ and `Tags <administration#tags-for-users>`__ for more fine-grained access restricions.
+See `Namespaces <administration.html#namespaces>`__ and `Tags <administration.html#tags-for-users>`__ for more fine-grained access restricions.
 
 .. note::
    In a future release, additional *Roles* may be introduced.
@@ -1018,9 +1018,9 @@ Add User
 
 Add a user account to the NetHSM.
 Each user account has a *Role*, which needs to be specified.
-Please refer to chapter `Roles <administration#roles>`__ to learn more about *Roles*.
+Please refer to chapter `Roles <administration.html#roles>`__ to learn more about *Roles*.
 
-Optionally, a user can be assigned to a `Namespace <administration#namespaces>`__.
+Optionally, a user can be assigned to a `Namespace <administration.html#namespaces>`__.
 
 .. note::
    The user ID must be alphanumeric.
@@ -1191,7 +1191,7 @@ An practically unlimited amount of Namespaces can be used without requiring addi
 
 *Namespaces* were introduced in software version 2.0. When migrating from an earlier version of the software, all existing users and keys will be without a Namespace.
 
-Users with the *Administrator* `Role <administration#roles>`__ are also referred to as *R-Administrator* if they are not in a Namespace, or *N-Administrator* if they are in a Namespace.
+Users with the *Administrator* `Role <administration.html#roles>`__ are also referred to as *R-Administrator* if they are not in a Namespace, or *N-Administrator* if they are in a Namespace.
 
 Special rules apply to *R-Administrator* users:
 They can set the Namespace for new users, list all users and query the Namespace of a user.
@@ -1300,7 +1300,7 @@ Tags for Users
 
 *Tags* can be used to set fine-grained access restrictions on keys, and are an optional feature. One or more *Tags* can be assigned to user accounts with the *Operator* role only. The *Operators* can see all keys, but only use those with at least one corresponding *Tag*. A key can not be modified by an *Operator* user.
 
-To learn about how to use *Tags* on keys, please refer to `Tags for Keys <operation#tags-for-keys>`__.
+To learn about how to use *Tags* on keys, please refer to `Tags for Keys <operation.html#tags-for-keys>`__.
 
 A *Tag* can be added as follows.
 

--- a/source/components/nethsm/container/production-image.rst
+++ b/source/components/nethsm/container/production-image.rst
@@ -31,7 +31,7 @@ The image can be run in two modes of operation, i.e. Unix process or unikernel.
 * The Unix process mode runs NetHSM as a process on top of the operating system.
 * The unikernel mode runs NetHSM as a guest in a KVM based virtual machine and provides strong separation from the host operating system. This mode is only available on Linux and requires access to the ``/dev/tun`` and ``/dev/kvm`` device nodes and the ``NET_ADMIN`` capability. For security reasons we recommend the unikernel mode.
 
-The mode can be set with the environment variable ``MODE`` (see next chapter `Configuration <container.html#production-image-configuration>`__).
+The mode can be set with the environment variable ``MODE`` (see next chapter `Configuration <production-image.html#Configuration>`__).
 
 Configuration
 ^^^^^^^^^^^^^
@@ -81,7 +81,7 @@ The container runtime secrets such as certificates and private keys need to be s
 Usage
 ^^^^^
 
-The production container supports two `modes of operation <container.html#Modes of Operation>`__. The following chapters describe how to run the container with the provided compose files or with the *run* command.
+The production container supports two `modes of operation <production-image.html#Modes of Operation>`__. The following chapters describe how to run the container with the provided compose files or with the *run* command.
 
 Unix Mode
 ~~~~~~~~~
@@ -91,7 +91,7 @@ Make sure you have the necessary files for the secrets, mentioned in the compose
 
 To run the container without the compose file you need to provide an external etcd yourself.
 `Here <https://quay.io/coreos/etcd>`__ you find the recommended container image for etcd.
-Make sure to pass the configuration options, as described in chapter `Configuration <container.html#production-image-configuration>`__.
+Make sure to pass the configuration options, as described in chapter `Configuration <production-image.html#Configuration>`__.
 
 The container can be executed as follows.
 
@@ -121,7 +121,7 @@ Make sure you have the necessary files for the secrets, mentioned in the compose
 
 To run the container without the compose file you need to provide an external etcd yourself.
 `Here <https://quay.io/coreos/etcd>`__ you find the recommended container image for etcd.
-Make sure to pass the configuration options, as described in chapter `Configuration <container.html#production-image-configuration>`__.
+Make sure to pass the configuration options, as described in chapter `Configuration <production-image.html#Configuration>`__.
 
 The container can be executed as follows.
 

--- a/source/components/nethsm/container/test-image.rst
+++ b/source/components/nethsm/container/test-image.rst
@@ -53,4 +53,4 @@ This will run NetHSM as a Unix process inside the container and expose the REST 
 .. important::
    The container uses a self-signed TLS certificate.
    Make sure to use the correct connection settings to establish a connection.
-   Please refer to chapter `NetHSM introduction <../getting-started#provisioning>`__ to learn more.
+   Please refer to chapter `NetHSM introduction <../getting-started.html#Provisioning>`__ to learn more.

--- a/source/components/nethsm/ejbca.rst
+++ b/source/components/nethsm/ejbca.rst
@@ -27,7 +27,7 @@ Executing The Example
 
 If you want to experiment with the given example you can use git to clone the `nethsm-pkcs11 repository <https://github.com/Nitrokey/nethsm-pkcs11>`__ and run the following commands:
 
-- Configure a NetHSM, either a real one or a container. See the `getting-started guide <getting-started>`__ for more information.
+- Configure a NetHSM, either a real one or a container. Refer to chapter `Getting Started <getting-started.html>`__ to learn more.
 - Change the libnethsm_pkcs11 configuration to match your NetHSM in ``container/ejbca/p11nethsm.conf``.
 - Build the container.
   

--- a/source/components/nethsm/index.rst
+++ b/source/components/nethsm/index.rst
@@ -1,7 +1,7 @@
 NetHSM
 ======
 
-This documentation describes the NetHSM software and hardware. The NetHSM software can be either used on the NetHSM hardware, or as a `software container <container>`__ (e.g. Docker).
+This documentation describes the NetHSM software and hardware. The NetHSM software can be either used on the NetHSM hardware, or as a `software container <container/index.html>`__ (e.g. Docker).
 
 The NetHSM software features a `REST API <https://nethsmdemo.nitrokey.com/api_docs/index.html>`_ to perform installation, administration and operational tasks. The recommended way to use a NetHSM is through the tool `nitropy <../software/nitropy/index.html>`_. Alternatively `curl <https://curl.se>`_ can be used to send HTTP requests to the REST API.
 

--- a/source/components/nextbox/faq/nextcloud.rst
+++ b/source/components/nextbox/faq/nextcloud.rst
@@ -50,7 +50,7 @@ Nextcloud FAQ
 
   This usually is an indication that the OS has unmounted/detached the internal
   hard-drive due to an low-power-incident. Please make sure you read and
-  understood `USB power <faq/hardware.html#why-must-i-not-connect-external-hard-drives-without-an-external-power-supply-to-my-nextbox>`_. In most
+  understood `USB power <hardware.html#why-must-i-not-connect-external-hard-drives-without-an-external-power-supply-to-my-nextbox>`__. In most
   cases doing a power-cycle (unplug the USB-C connector, wait 5secs and plug it
   in again) should resolve this. **Make sure no additional USB devices are
   connected during this procedure.**

--- a/source/components/nitrokeys/features/openpgp-card/fedora-gnupg-configuration.rst
+++ b/source/components/nitrokeys/features/openpgp-card/fedora-gnupg-configuration.rst
@@ -5,7 +5,7 @@ OpenPGP smartcard with GnuPG on Fedora
 
 .. note::
    The following instructions require the Nitrokey 3 to have at least firmware version ``1.4.0`` installed.
-   Please refer to `firmware update <./firmware-update.html>`__ to learn how to update it.
+   Please refer to `firmware update <../../nitrokey3/firmware-update.html>`__ to learn how to update it.
 
 The GnuPG smartcard support requires *scdaemon*.
 In Fedora the *scdaemon* is part of the GnuPG package.

--- a/source/components/nitrokeys/features/openpgp-card/hard-disk-encryption/luks.rst
+++ b/source/components/nitrokeys/features/openpgp-card/hard-disk-encryption/luks.rst
@@ -29,9 +29,7 @@ Requirements
 
 See the section below to determine which method is compatible with this guide.
 
--  A Nitrokey Pro 2 or Nitrokey Storage 2
-   `initialized <openpgp.html>`_
-   with keys.
+-  A Nitrokey Pro 2 or Nitrokey Storage 2 initialized with keys.
 
 Known Issues
 ------------

--- a/source/components/nitrokeys/features/openpgp-card/openpgp-csp.rst
+++ b/source/components/nitrokeys/features/openpgp-card/openpgp-csp.rst
@@ -92,7 +92,7 @@ If you did not enforce the usage of OpenPGP-CSP you have to choose it here now.
 
 Next you choose the Authentication slot for the certificate.
 
-You are now ready to logon on the computer with the Nitrokey instead of your password and you can use `S/MIME email encryption/signing <smime.html>`_ with the Nitrokey. The driver has to be installed on every computer you want to use the certificate on.
+You are now ready to logon on the computer with the Nitrokey instead of your password and you can use `S/MIME email encryption/signing <smime/index.html>`_ with the Nitrokey. The driver has to be installed on every computer you want to use the certificate on.
 
 .. figure:: images/openpgp-csp/11.png
    :alt: img11

--- a/source/components/nitrokeys/features/openpgp-card/openpgp-keygen-backup.rst
+++ b/source/components/nitrokeys/features/openpgp-card/openpgp-keygen-backup.rst
@@ -79,7 +79,7 @@ We can use the command ``gpg --full-generate-key --expert`` to start a guided ke
    sub   rsa2048 2018-09-17 [E]
 
 .. note::
-     For information regarding the supported algorithms, please refer to the `faq <../faq.html>`_
+     For information regarding the supported algorithms, refer to the FAQ of the respective Nitrokey model.
 
 
 Subkey for Authentication

--- a/source/components/nitrokeys/features/openpgp-card/openpgp-outlook.rst
+++ b/source/components/nitrokeys/features/openpgp-card/openpgp-outlook.rst
@@ -13,7 +13,7 @@ Outlook
 Prerequisites
 -------------
 
-If you do not have PGP-Keys on your Nitrokey yet, please look at `this page <openpgp.html>`_ first.
+If you do not have PGP-Keys on your Nitrokey yet, please look at `this page <index.html>`_ first.
 
 You need to have GnuPG installed on your System. The newest GnuPG version for Windows can be found `here <https://www.gpg4win.org>`__. You need to make sure to have “GpgOL” checked during installation process (see below).
 

--- a/source/components/nitrokeys/features/openpgp-card/openvpn/easyrsa.rst
+++ b/source/components/nitrokeys/features/openpgp-card/openvpn/easyrsa.rst
@@ -15,7 +15,7 @@ This guide shows how to configure OpenVPN clients to login using a `Nitrokey Pro
 2 <https://shop.nitrokey.com/de_DE/shop/product/nitrokey-storage-2-56>`__. For software key management we will be using `Easy-RSA <https://github.com/OpenVPN/easy-rsa>`__, a utility that has been evolving alongside OpenVPN.
 
 To sign the certificates, we will use a `Nitrokey HSM
-2 <https://shop.nitrokey.com/shop/nkhs2-nitrokey-hsm-2-7>`__ set up as `Certificate Authority <certificate-authority.html#creating-the-intermediate-certificate-authority>`_, however this guide does not cover the set up of the CA itself (it is clear and `well documented here <certificate-authority.html#sign-a-server-certificate>`_).
+2 <https://shop.nitrokey.com/shop/nkhs2-nitrokey-hsm-2-7>`__ set up as `Certificate Authority <../certificate-authority.html#creating-the-intermediate-certificate-authority>`_, however this guide does not cover the set up of the CA itself (it is clear and `well documented here <../certificate-authority.html#sign-a-server-certificate>`_).
 
 We will use Easy-RSA, because it seems to provide some flexibility, and allows key management via external PKIs. We will use it on the server to issue the signing request, and repeat the same process on the client. The Certificate Signing Requests will be signed by the CA on the Nitorkey HSM, and re-transmitted to the server and the client.
 
@@ -51,7 +51,7 @@ We will use the following Nitrokeys for physical key management:
 -  A Certificate Authority (CA) using the `Nitrokey HSM 2
    (pdf) <https://www.nitrokey.com/files/doc/Nitrokey_HSM_factsheet.pdf>`__
 
-As a reminder, to build a Certificate Authority on Nitrokey HSM 2, you may follow the instructions available `in the documentation <certificate-authority.html#sign-a-server-certificate>`_.
+As a reminder, to build a Certificate Authority on Nitrokey HSM 2, you may follow the instructions available `in the documentation <../certificate-authority.html#sign-a-server-certificate>`_.
 
 Alternatively you may set up your own CA on a `on a separate machine <https://www.digitalocean.com/community/tutorials/how-to-set-up-and-configure-a-certificate-authority-ca-on-ubuntu-20-04>`__, or use the OpenVPN tutorial which also relies on `Easy-RSA <https://openvpn.net/community-resources/setting-up-your-own-certificate-authority-ca/>`__. The last 2 options rely on software solutions for key management.
 
@@ -236,7 +236,7 @@ Server side
 
     The transfer itself is not security sensitive, though it is wise to verify if the received file matches the sender’s copy, if the transport is untrusted.
 
-    In order to go through these steps, I will extensively rely on `these instructions <certificate-authority.html#creating-the-intermediate-certificate-authority>`_, to sign the certificate signing requests, once we generated them with Easy-RSA.
+    In order to go through these steps, I will extensively rely on `these instructions <../certificate-authority.html#creating-the-intermediate-certificate-authority>`_, to sign the certificate signing requests, once we generated them with Easy-RSA.
 
     1. Sign the ``server.req`` file
 

--- a/source/components/nitrokeys/features/openpgp-card/openvpn/viscosity.rst
+++ b/source/components/nitrokeys/features/openpgp-card/openvpn/viscosity.rst
@@ -14,7 +14,7 @@ Prerequisites
 
 For this guide, you will need an OpenVPN remote server installed and configured for clients. For the purpose of this document, we have used OpenVPN 2.49 installed on a Debian 10 server.
 
-To read about how to configure OpenVPN to authenticate with Nitrokey Pro, you might consult the following `documentation <openvpn-easyrsa.html>`_, as we will just cover the way to configure the Viscosity client in this guide.
+To read about how to configure OpenVPN to authenticate with Nitrokey Pro, you might consult the following `documentation <easyrsa.html>`_, as we will just cover the way to configure the Viscosity client in this guide.
 
 You will also need the following:
 

--- a/source/components/nitrokeys/features/openpgp-card/smime/index.rst
+++ b/source/components/nitrokeys/features/openpgp-card/smime/index.rst
@@ -14,7 +14,7 @@ There are two widely used standards for email encryption.
 
 -  S/MIME/X.509 is mostly used by enterprises.
 
-If you are in doubt which one to choose, you should use OpenPGP, see `here <../openpgp/index.html>`_ (not applicable for the Nitrokey HSM 2, the Nitrokey HSM 2 currently supports the S/MIME/X.509 standard though, therefore the rest of the guide is applicable for the HSM 2 and other Nitrokeys). This page describes the usage of S/MIME email encryption.
+If you are in doubt which one to choose, you should use OpenPGP, see `here <index.html>`_ (not applicable for the Nitrokey HSM 2, the Nitrokey HSM 2 currently supports the S/MIME/X.509 standard though, therefore the rest of the guide is applicable for the HSM 2 and other Nitrokeys). This page describes the usage of S/MIME email encryption.
 
 You need to purchase a S/MIME certificate (e.g. at `CERTUM <https://www.certum.eu/en/cert_offer_cert_id/>`__) or may already got one by your company. Furthermore, you need to install `OpenSC <https://github.com/OpenSC/OpenSC/wiki>`__ on your System. While GNU/Linux users usually can install OpenSC over the package manager (e.g. ``sudo apt install opensc`` on Ubuntu), macOS and Windows users can download the installation files from the `OpenSC <https://github.com/OpenSC/OpenSC/releases>`__ page.
 

--- a/source/components/nitrokeys/nitrokey3/overview.rst
+++ b/source/components/nitrokeys/nitrokey3/overview.rst
@@ -43,14 +43,14 @@ features are realized.
      - no
 
    * - Admin App
-     - Administration functions used by `pynitrokey`_ and `NitrokeyApp2`_
+     - Administration functions used by `pynitrokey`_ and `Nitrokey-App2`_
      - USB
      - no
 
 .. note::
    Secure element support for OpenPGP Card is available since stable firmware v1.7.0. Any new 
    devices will have this automatically activated. For devices already in use, the
-   user has to `manually switch`_ as described in the FAQ.
+   user has to `manually switch <secure-element.html>`__ as described in the FAQ.
 
 
 On top of the stable firmware for the Nitrokey 3, we also provide a `Test Firmware`_, which
@@ -80,18 +80,18 @@ data migrations from test to stable firmwares will not be implemented.**
      - no
 
 
-.. _FIDO2: ../features/fido/index.html
+.. _FIDO2: ../features/fido2/index.html
 .. _U2F: ../features/u2f/index.html
 .. _OpenPGP Card: ../features/openpgp-card/index.html
 .. _Password Safe: ../features/password-safe/index.html
-.. _PIV: ../features/piv/index
+.. _PIV: ../features/piv/index.html
 .. _WebSmartCard: https://github.com/Nitrokey/nitrokey-websmartcard
-.. _S/MIME: ../features/smime/index.html
+.. _S/MIME: ../features/openpgp-card/smime/index.html
 
-.. _pynitrokey: ../software/nitropy/index.html
-.. _NitrokeyApp2: ../software/nk-app2/index.html
+.. _pynitrokey: ../../software/nitropy/index.html
+.. _Nitrokey-App2: ../../software/nk-app2/index.html
 
-.. _Test Firmware: linux/firmware-update#firmware-release-types
+.. _Test Firmware: firmware-update.html#firmware-release-types
 
 
 .. _manually switch: faq#how-can-I-use-the-se050-secure-element

--- a/source/components/nitrokeys/pro/getting-started.rst
+++ b/source/components/nitrokeys/pro/getting-started.rst
@@ -29,9 +29,9 @@ Getting Started
 
 
 2. Download and start the `Nitrokey
-   App <https://www.nitrokey.com/download>`__. Follow the
-   `instructions <../product-guides/change-pins/index.html>`_
-   to change the default User PIN (default: 123456) and Admin PIN
+   App <https://www.nitrokey.com/download>`__. 
+
+3. Use the Nitrokey-App to change the default User PIN (default: 123456) and Admin PIN 
    (default: 12345678) to your own choices.
 
 .. figure:: ../features/openpgp-card/images/change-pins/App-change-pin.png
@@ -67,7 +67,7 @@ by enterprises. If you are in doubt which one to choose, you should use
 OpenPGP.
 
 To learn more about how to use OpenPGP for email encryption with the Nitrokey,
-please refer to chapter `OpenPGP Email Encryption <../features/openpgp/index.html>`_.
+please refer to chapter `OpenPGP Email Encryption <../features/openpgp-card/index.html>`_.
 
 To learn more about how to use S/MIME for email encryption with the Nitrokey,
-please refer to chapter `S/MIME Email Encryption <../features/smime/index.html>`_.
+please refer to chapter `S/MIME Email Encryption <../features/openpgp-card/smime/index.html>`_.

--- a/source/components/nitrokeys/pro/index.rst
+++ b/source/components/nitrokeys/pro/index.rst
@@ -26,7 +26,7 @@ or check out the features:
 * `U2F <../features/u2f/index.html>`_
 * `TOTP <../features/totp/index.html>`_
 * `OpenPGP Card <../features/openpgp-card/index.html>`_
-* `Automatic Screen Lock (Linux) <../features/misc/automatic-screen-lock/index.html>`_
-* `ECC <../features/misc/ecc/index.html>`_
+* `Automatic Screen Lock (Linux) <../features/misc/automatic-screen-lock.html>`_
+* `ECC <../features/misc/ecc.html>`_
 
 

--- a/source/components/nitrokeys/start/getting-started.rst
+++ b/source/components/nitrokeys/start/getting-started.rst
@@ -55,10 +55,10 @@ S/MIME/x.509 is mostly used by enterprises. If you are in doubt which
 one to choose, you should use OpenPGP.
 
 To learn more about how to use OpenPGP for email encryption with the Nitrokey,
-please refer to chapter `OpenPGP Email Encryption <openpgp.html>`_.
+please refer to chapter `OpenPGP Email Encryption <../features/openpgp-card/overview.html>`_.
 
 To learn more about how to use S/MIME for email encryption with the Nitrokey,
-please refer to chapter `S/MIME Email Encryption <smime.html>`_.
+please refer to chapter `S/MIME Email Encryption <../features/openpgp-card/smime/index.html>`_.
 
 Please note that the Nitrokey App can not be used for this device!
 

--- a/source/components/nitrokeys/storage/getting-started.rst
+++ b/source/components/nitrokeys/storage/getting-started.rst
@@ -71,8 +71,8 @@ by enterprises. If you are in doubt which one to choose, you should use
 OpenPGP.
 
 To learn more about how to use OpenPGP for email encryption with the Nitrokey,
-please refer to chapter `OpenPGP Email Encryption <../features/openpgp/index.html>`_.
+please refer to chapter `OpenPGP Email Encryption <../features/openpgp-card/index.html>`_.
 
 To learn more about how to use S/MIME for email encryption with the Nitrokey,
-please refer to chapter `S/MIME Email Encryption <../features/smime/index.html>`_.
+please refer to chapter `S/MIME Email Encryption <../features/openpgp-card/smime/index.html>`_.
 

--- a/source/components/nitrokeys/storage/index.rst
+++ b/source/components/nitrokeys/storage/index.rst
@@ -28,5 +28,5 @@ or check out the features:
 * `OpenPGP Card <../features/openpgp-card/index.html>`_
 * `Encrypted Mobile Storage <../features/encrypted-storage/index.html>`_
 * `Hidden Storage <../features/hidden-storage/index.html>`_
-* `Automatic Screen Lock (Linux) <../features/misc/automatic-screen-lock/index.html>`_
-* `ECC <../features/misc/ecc/index.html>`_
+* `Automatic Screen Lock (Linux) <../features/misc/automatic-screen-lock.html>`_
+* `ECC <../features/misc/ecc.html>`_

--- a/source/components/nitropad-nitropc/troubleshooting.rst
+++ b/source/components/nitropad-nitropc/troubleshooting.rst
@@ -34,7 +34,7 @@ steps:
    .. figure:: /components/nitropad-nitropc/images/options.jpg
       :alt: img2
 
-3. After that, please follow `these instructions <system-update.html>`_ from step 3 onwards.
+3. After that, please follow `these instructions <heads/system-update.html>`_ from step 3 onwards.
 
 NitroPad doesn’t start
 ----------------------

--- a/source/components/nitrophone/hmdm/server-update.rst
+++ b/source/components/nitrophone/hmdm/server-update.rst
@@ -7,7 +7,7 @@ Before you perform the update on the server, make sure your mobile devices run a
 .. important::
    An incompatible launcher app version can cause a loose of communication between the server and the mobile devices.
    To prevent this, update the launcher app on the mobile devices first.
-   Please refer to chapter `Verify Update on Mobile Devices <launcher-app-update#Verify Update on Mobile Devices>`__ to learn more.
+   Please refer to chapter `Verify Update on Mobile Devices <launcher-app-update.html#Verify Update on Mobile Devices>`__ to learn more.
 
 The installation files you can request from our support team.
 In case of an update only the WAR file for the application server is required.

--- a/source/components/software/nk-app2/index.rst
+++ b/source/components/software/nk-app2/index.rst
@@ -4,7 +4,7 @@ Nitrokey App 2 is the graphical application for Nitrokey 3 devices. For Nitrokey
 
 Installation
 ------------
-Download it for `Linux <installation-linux>`__ , `Windows <installation-windows>`__ or `macOS <installation-mac>`__ (pipenv only).
+Download it for `Linux <installation-linux.html>`__ , `Windows <installation-windows.html>`__ or `macOS <installation-mac.html>`__ (pipenv only).
 
 
 Supported Features


### PR DESCRIPTION
This PR fixes all the hyperlinks which are internal links, i.e. pointing to our own documentation.