### PR TITLE
Hyperlinks nightly

### DIFF
--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -1,0 +1,17 @@
+name: CI - Nightly
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  check-hyperlinks:
+    name: Check hyperlinks
+    runs-on: ubuntu-latest
+    container: python:3.11
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Create virtual environment
+        run: make venv
+      - name: Check hyperlinks
+        run: make check-hyperlinks-nightly

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ check-syntax: venv
 check-hyperlinks: venv docs
 	venv/bin/linkchecker -f linkcheckerrc dist/en/index.html
 
+.PHONE: check-hyperlinks-nightly
+check-hyperlinks-nightly: venv
+	venv/bin/linkchecker -f linkcheckerrc_nightly dist/en/index.html
+
 .PHONY: pkg
 pkg: venv docs
 	mv dist/en/_images dist/_images

--- a/linkcheckerrc_nightly
+++ b/linkcheckerrc_nightly
@@ -1,0 +1,11 @@
+[filtering]
+checkextern=1
+ignore=
+  (?m)/(de|fr|es|nl|it|ja|ru|el|da|bg|et|fi|lv|lt|pl|pt|ro|sv|sk|sl|cs|hu|zh_CN)+/
+
+[checking]
+threads=1
+
+[output]
+warnings=1
+


### PR DESCRIPTION
This PR adds a nightly CI pipeline check for all hyperlinks. This includes also external links, as in contrast to the regular CI pipeline.

The execution is limited to one thread with the intention to not run into any rate limitings.
Pipeline run is scheduled to every night at 2:00h UTC (Berlin 4:00h).