### PR TITLE
Add edit page exclude configuration and excludes

### DIFF
--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -170,8 +170,10 @@
                     <!-- User defined GitHub URL -->
                     <a href="{{ meta['github_url'] }}"> {{ _('Edit on GitHub') }}</a>
                 {% else %}
-                  <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}/{{ conf_py_path }}/{{ pagename }}{{ suffix }}"> {{ _('Edit this Page') }}</a> | 
-                  <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/issues/new?body=File:%20[{{ pagename }}{{ suffix }}]%20https://docs.nitrokey.com/{{ pagename }}.html"> {{ _('Request docs change') }}</a>
+                    {% if hasdoc(pagename) and pagename not in github_edit_excludes %}
+                        <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}/{{ conf_py_path }}/{{ pagename }}{{ suffix }}"> {{ _('Edit this Page') }}</a> |
+                        <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/issues/new?body=File:%20[{{ pagename }}{{ suffix }}]%20https://docs.nitrokey.com/{{ pagename }}.html"> {{ _('Request docs change') }}</a>
+		    {% endif %}
                 {% endif %}
                 {% elif show_source and source_url_prefix %}
                 <a href="{{ source_url_prefix }}{{ pagename }}{{ suffix }}">{{ _('View page source') }}</a>

--- a/source/conf.py
+++ b/source/conf.py
@@ -83,6 +83,25 @@ exclude_patterns = [
     "components/to-be-integrated.rst",
 ]
 
+# List of page names to exclude from adding a
+# "Edit this Page" and "Request docs change" link in the page footer
+github_edit_excludes = [
+    "search",
+    "genindex",
+    "components/software/nitrokey-sdk-py/index",
+    "components/software/nitrokey-sdk-py/guides/index",
+    "components/software/nitrokey-sdk-py/guides/usage",
+    "components/software/nitrokey-sdk-py/api/index",
+    "components/software/nitrokey-sdk-py/api/nitrokey.nk3",
+    "components/software/nitrokey-sdk-py/api/nitrokey.nk3.secrets_app",
+    "components/software/nitrokey-sdk-py/api/nitrokey.nk3.updates",
+    "components/software/nitrokey-sdk-py/api/nitrokey.nkpk",
+    "components/software/nitrokey-sdk-py/api/nitrokey.trussed",
+    "components/software/nitrokey-sdk-py/api/nitrokey.trussed.admin_app",
+    "components/software/nitrokey-sdk-py/api/nitrokey.trussed.provisioner_app",
+    "components/software/nitrokey-sdk-py/api/nitrokey.updates",
+]
+
 # The name of the Pygments (syntax highlighting) style to use.
 # pygments_style = "solarizeddark"
 # pygments_style = "cheerfully_dark"
@@ -109,6 +128,7 @@ html_context = {
     "github_user": "Nitrokey",  # Username
     "github_repo": "nitrokey-documentation",
     "github_version": "main",  # Version
+    "github_edit_excludes": github_edit_excludes,
     "conf_py_path": "source",  # Path in the checkout to the docs root
     "suffix": ".rst",
     "copyrightlink": "https://www.nitrokey.com",


### PR DESCRIPTION
This PR adds a mechanism to exclude pages from adding the "Edit this Page" and "Request docs change" links in the footer. As some pages are dynamically generated, such as *search* and *genindex* they can't be edited through these links. Effectively these links always lead to a HTTP 404 error as the page doesn't exist in the repository on GitHub.

Also includes all pages of the *nitrokey-sdk-py*.