### PR TITLE
Add NetHSM database storage path information

### DIFF
--- a/source/components/nethsm/container/production-image.rst
+++ b/source/components/nethsm/container/production-image.rst
@@ -75,6 +75,13 @@ The container runtime secrets such as certificates and private keys need to be s
 |                      | in the system design.                                                                                                            |
 +----------------------+----------------------------------------------------------------------------------------------------------------------------------+
 
+Data Storage
+~~~~~~~~~~~~
+
+The system configuration, keys and certificates are stored in an etcd database.
+The etcd service stores the database in the ``/data`` path of the container.
+Container executors allow to volume or bind mount this path.
+
 Usage
 ^^^^^
 

--- a/source/components/nethsm/container/test-image.rst
+++ b/source/components/nethsm/container/test-image.rst
@@ -29,6 +29,13 @@ The image can be configured with the following environment variables.
 | ``DEBUG_LOG``        | Enables extended logging for NetHSM. |
 +----------------------+--------------------------------------+
 
+Data Storage
+~~~~~~~~~~~~
+
+The system configuration, keys and certificates are stored in an etcd database.
+The etcd service stores the database in the ``/data`` path of the container.
+Container executors allow to volume or bind mount this path.
+
 Usage
 ^^^^^
 


### PR DESCRIPTION
This PR adds a short explanation about the database storage path of the etcd service in the NetHSM container.