### PR TITLE
Remove outdated windows only specification for PIV

### DIFF
--- a/source/components/nitrokeys/nitrokey3/index.rst
+++ b/source/components/nitrokeys/nitrokey3/index.rst
@@ -34,4 +34,4 @@ or check out the features:
 * `U2F <../features/u2f/index.html>`_
 * `OpenPGP Card <../features/openpgp-card/index.html>`_
 * `Password Safe <../features/password-safe/index.html>`_
-* `PIV (Windows only) <../features/piv/index.html>`_
+* `PIV <../features/piv/index.html>`_


### PR DESCRIPTION
The PIV documentation now contains also commands for operations on other operating systems