### PR TITLE
Add note about the TLS certificates for the NetHSM production container

### DIFF
--- a/source/components/nethsm/container/production-image.rst
+++ b/source/components/nethsm/container/production-image.rst
@@ -75,6 +75,10 @@ The container runtime secrets such as certificates and private keys need to be s
 |                      | in the system design.                                                                                                            |
 +----------------------+----------------------------------------------------------------------------------------------------------------------------------+
 
+.. important::
+   The TLS certificates used for the *etcd* service, web API and the client authentication certificate, must both contain a valid Subject Alternative Name (SAN).
+   Otherwise the *etcd* service will reject them as invalid.
+
 Data Storage
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR adds a note about the TLS certificates for the NetHSM production container.