### PR TITLE
Update requirements for u2f destop login

### DIFF
--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -19,8 +19,7 @@ Requirements
 
 -  Ubuntu 20.04 with Gnome Display Manager.
 
--  Nitrokey FIDO2 configured following `these
-   instructions <https://docs.nitrokey.com/fido2/linux>`__.
+-  A FIDO2 capable Nitrokey: see table ``Compatible Nitrokeys`` at the top of the page for reference.
 
 Instructions
 ------------


### PR DESCRIPTION
Now referencing all FIDO2 capable Nitrokeys, without the need to configure it at this point.
closes #437 