### PR TITLE
u2f desktop login: remove nouserok and add troubleshooting

### DIFF
--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -17,7 +17,7 @@ If you want to login to you computer using `Nitrokey Pro
 Requirements
 ------------
 
--  Ubuntu 20.04 with Gnome Display Manager.
+-  Ubuntu 20.04 with Gnome Display Manager (GDM).
 
 -  A FIDO2 capable Nitrokey: see table ``Compatible Nitrokeys`` at the top of the page for reference.
 
@@ -294,3 +294,23 @@ In step 7 we have used the ``sufficient`` control flag to determine the behavior
    -  You will also lose the ability to use ``sudo`` if you set up
       Central Authentication Mapping *and* used the ``required`` or
       ``requisite`` flags.
+
+   -  You might also lose the ability to log in using Gnome Display manager
+      if smart card login is enforced and you used the ``required`` or. 
+      ``requisite`` flags. See Troubleshooting for further info.
+
+
+Troubleshooting
+---------------
+
+Issues logging into user account using GDM
+''''''''''''''''''''''''''''''''''''''''''
+
+In some cases, for example if you have `opencs-pkcs11` installed, Gnome Display Manager (GDM) can
+default to enforcing smart card login as soon as any smart card (like your Nitrokey) is plugged in, even if no smart card has ever been configured. 
+This can prevent you from logging in to your user account using u2f. If you have set the ``sufficient`` control flag,
+unplug all smart cards and log in using your password. To turn off smart card enforcing run the following command:
+
+.. code-block:: bash
+
+   $ sudo -u gdm env -u XDG_RUNTIME_DIR -u DISPLAY DCONF_PROFILE=gdm dbus-run-session gsettings set org.gnome.login-screen enable-smartcard-authentication false

--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -79,7 +79,7 @@ Instructions
 
       $ pamu2fcfg > ~/u2f_keys
 
-   Once you run the command above, you will need to touch the device while it flashes. Once done, ``pamu2fcfg`` will append its output the ``u2f_keys`` in the format:
+   Once you run the command above, you will need to touch the device while it flashes. Once done, ``pamu2fcfg`` will append its output the ``u2f_keys`` file in the format:
 
    .. code-block:: bash
 
@@ -92,13 +92,6 @@ Instructions
       nitrouser:fS6vQ9uWa0VizcczyZ/bvk5kcQJkIJOC/21/e7dXFe/fnONSL705EkeiUpZpL/3seAWL/qW4/mqb0/WtiZoP/NOLTRM4EEAg1ANLsfYgSzRd/AjsW3z8kJwgckbvwDUyB90ByR09XtBhuE41vMsEk6J+9CS0+ZuPSB0KXRG7z2yZpQLldjE/ijsdIdd8Ct2oXSiZ/zTb/t5kRafNJVkp=,Oo4U9XvIhI9r0WNnvoMwG5/pbgwYd4GMCYEinhWcsI2hKUebYj92JOxDsSa3zd2A9OB0ofXgB16FD2naev3YmLch==,es256,+presence
 
    Note, this output was not generated directly by ``pamu2fcfg`` and contains no sensitive information. It is purely meant to show the expected format and length of the output.
-   For better security, after the config file generated, we will move the generated file ``~/u2f_keys`` directory under the ``/etc/Nitrokey/`` directory and change the access permissions with these commands:
-
-   .. code-block:: bash
-
-      $ sudo mkdir /etc/Nitrokey
-      $ sudo mv ~/u2f_keys /etc/Nitrokey/
-      $ sudo chmod 644 /etc/Nitrokey/u2f_keys
 
    .. tip::
 
@@ -121,13 +114,29 @@ Instructions
 
    This step is optional, however it is advised to have a backup Nitrokey in the case of loss, theft or destruction of your primary Nitrokey.
 
-   To set up a backup key, repeat the procedure above, and use ``pamu2fcfg -n``. This will omit the ``<username>`` field, and the output can be appended to the line with your ``<username>`` like this:
+   To set up a backup key, repeat the procedure above, and use ``pamu2fcfg -n`` like this:
 
    .. code-block:: bash
 
-      <username>:Zx...mw,04...0a:xB...fw,04...3f
+      $ pamu2fcfg -n >> ~/u2f_keys
 
-5. **Modify the Pluggable Authentication Module** ``PAM``
+   This will omit the ``<username>`` field, and the output is appended to the line with your ``<username>``, this will look something like this:
+   
+   .. code-block:: bash
+
+      <username>:Zx...mw,04...0a:xB...fw,es256,+presence:04...3f,es256,+presence
+   
+5. **Securing the config file**
+
+   For better security, after the config file generated, we will move the generated file ``~/u2f_keys`` directory to ``/etc/Nitrokey/`` and change the access permissions with these commands:
+
+   .. code-block:: bash
+
+      $ sudo mkdir /etc/Nitrokey
+      $ sudo mv ~/u2f_keys /etc/Nitrokey/
+      $ sudo chmod 644 /etc/Nitrokey/u2f_keys
+
+6. **Modify the Pluggable Authentication Module** ``PAM``
 
    The final step is configure the PAM module files under ``/etc/pam.d/``. In this guide we will modify the ``common-auth`` file as it handles the authentication settings which are common to all services, but other options are possible. You can modify the file with the following command:
 
@@ -201,7 +210,7 @@ There are several PAM modules files that can be modified according to your needs
 Control Flags
 ''''''''''''''''''''''''
 
-In step 5 we have used the ``sufficient`` control flag to determine the behavior of the PAM module when the Nitrokey is plugged or not. However it is possible to change this behavior by using the following control flags:
+In step 6 we have used the ``sufficient`` control flag to determine the behavior of the PAM module when the Nitrokey is plugged or not. However it is possible to change this behavior by using the following control flags:
 
 -  ``required``: This is the most critical flag. The module result must
    be successful for authentication to continue. This flag can lock you

--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -8,7 +8,7 @@ Desktop Login And Linux User Authentication
 Introduction
 ------------
 
-This guide will walk you through the configuration of Linux to use FIDO Universal 2nd Factor, i.e. FIDO U2F with ``libpam-u2f`` and Nitrokey FIDO2.
+This guide will walk you through the configuration of Linux to use FIDO Universal 2nd Factor, i.e. FIDO U2F with ``libpam-u2f`` and compatible Nitrokeys.
 
 If you want to login to you computer using `Nitrokey Pro
 2, <https://shop.nitrokey.com/shop/product/nk-pro-2-nitrokey-pro-2-3>`__ `Nitrokey Storage
@@ -17,7 +17,7 @@ If you want to login to you computer using `Nitrokey Pro
 Requirements
 ------------
 
--  Ubuntu 20.04 with Gnome Display Manager (GDM).
+-  Ubuntu 24.04 with Gnome Display Manager (GDM).
 
 -  A FIDO2 capable Nitrokey: see table ``Compatible Nitrokeys`` at the top of the page for reference.
 
@@ -82,7 +82,7 @@ CLI Method
       modules <https://www.man7.org/linux/man-pages/man8/pam.8.html>`__.
 
 
-2. **Set up the** ``rules`` **to recognize the Nitrokey FIDO2**
+2. **Set up the** ``rules`` **to recognize the Nitrokey**
 
    Under ``/etc/udev/rules.d`` download ``41-nitrokey.rules``
 
@@ -99,7 +99,7 @@ CLI Method
 
 3. **Install** ``libpam-u2f``
 
-   On Ubuntu 20.04 it is possible to download directly ``libpam-u2f`` from the official repos
+   On Ubuntu 24.04 it is possible to download directly ``libpam-u2f`` from the official repos
 
    .. code-block:: bash
 
@@ -134,13 +134,13 @@ CLI Method
 
       $ mkdir ~/.config/Nitrokey
 
-   And plug your Nitrokey FIDO2.
+   And plug your Nitrokey.
 
-   Once done with the preparation, we can start to configure the computer to use the Nitrokey FIDO2 for 2nd factor authentication at login and ``sudo``.
+   Once done with the preparation, we can start to configure the computer to use the Nitrokey for 2nd factor authentication at login and ``sudo``.
 
 5. **Generate the U2F config file**
 
-   To generate the configuration file we will use the ``pamu2fcfg`` utility that comes with the ``libpam-u2f``. For convenience, we will directly write the output of the utility to the ``u2f_keys`` file under ``.config/Nitrokey``. First plug your Nitrokey FIDO2 (if you did not already), and enter the following command:
+   To generate the configuration file we will use the ``pamu2fcfg`` utility that comes with the ``libpam-u2f``. For convenience, we will directly write the output of the utility to the ``u2f_keys`` file under ``.config/Nitrokey``. First plug your Nitrokey (if you did not already), and enter the following command:
 
    .. code-block:: bash
 
@@ -178,7 +178,7 @@ CLI Method
 
 6. **Backup**
 
-   This step is optional, however it is advised to have a backup Nitrokey in the case of loss, theft or destruction of your Nitrokey FIDO.
+   This step is optional, however it is advised to have a backup Nitrokey in the case of loss, theft or destruction of your primary Nitrokey.
 
    To set up a backup key, repeat the procedure above, and use ``pamu2fcfg -n``. This will omit the ``<username>`` field, and the output can be appended to the line with your ``<username>`` like this:
 
@@ -199,7 +199,7 @@ CLI Method
 
    .. code-block:: bash
 
-      #Nitrokey FIDO2 config
+      #Nitrokey config
       auth    sufficient pam_u2f.so authfile=/etc/Nitrokey/u2f_keys cue [cue_prompt=Please touch the device.] prompt
 
    .. tip::
@@ -225,7 +225,7 @@ CLI Method
       nitrouser@nitrouser:~$ sudo ls
       [sudo] password for nitrouser:  Please touch the device.
 
-   You can also test your configuration by logging out of the user session and logging back. A similar screen should be displayed once you you unplug/replug yout Nitrokey FIDO2 and type your password:
+   You can also test your configuration by logging out of the user session and logging back. A similar screen should be displayed once you you unplug/replug yout Nitrokey and type your password:
 
    .. figure:: images/desktop-login/u2f-fido-pam-2.png
       :alt: img6
@@ -233,11 +233,11 @@ CLI Method
 Usage
 -----
 
-After the PAM module modification, you will be able to test your configuration right away, but it is recommended to reboot your computer, and unplug/replug the Nitrokey FIDO2.
+After the PAM module modification, you will be able to test your configuration right away, but it is recommended to reboot your computer, and unplug/replug the Nitrokey.
 
 Once you have properly tested the instructions in this guide (and set up a backup), it is recommended to use either the ``required`` or the ``requisite`` control flag instead of ``sufficient``.
 
-The flags ``required`` and ``requisite`` provide a tighter access control, and will make the Nitrokey FIDO2 necessary to login, and/or use the configured service.
+The flags ``required`` and ``requisite`` provide a tighter access control, and will make the Nitrokey necessary to login, and/or use the configured service.
 
 If you need more information about Control Flags in the ``PAM``
 configuration line, you may see the last section of this guide to understand the difference, and the implications of using each of them.
@@ -248,7 +248,7 @@ PAM Modules
 There are several PAM modules files that can be modified according to your needs:
 
 -  By modifying ``/etc/pam.d/common-auth`` file, you will be able to use
-   you Nitrokey FIDO for 2nd factor authentication for graphic login and
+   you Nitrokey for 2nd factor authentication for graphic login and
    ``sudo``. Note: ``common-auth`` should be modified by adding the
    additional configuration line at the end of the file.
 
@@ -285,7 +285,7 @@ In step 7 we have used the ``sufficient`` control flag to determine the behavior
 
    -  If ``required`` or ``requisite`` is set, the failure of U2F
       authentication will cause a failure of the overall authentication.
-      Failure will occur when the configured Nitrokey FIDO is not
+      Failure will occur when the configured Nitrokey is not
       plugged, lost or destroyed.
 
    -  You will lose access to your computer if you mis-configured the

--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -5,6 +5,16 @@ Desktop Login And Linux User Authentication
 
 .. contents:: :local:
 
+.. warning::
+
+   The following guide can potentially lock you out of your computer.
+   You should be aware of these risks, as it is recommended to first use
+   the instructions below on a secondary computer, or after a full
+   backup.
+
+   You might lose access to your data after configuring `PAM
+   modules <https://www.man7.org/linux/man-pages/man8/pam.8.html>`__.
+
 Introduction
 ------------
 
@@ -19,14 +29,10 @@ Requirements
 
 -  Ubuntu 24.04 with Gnome Display Manager (GDM).
 
--  A FIDO2 capable Nitrokey: see table ``Compatible Nitrokeys`` at the top of the page for reference.
-
 Instructions
 ------------
 
 1. **Create a backup user and give it root privileges**
-
-   You can do so by using these commands:
 
    .. rstcheck: ignore-next-code-block
    .. code-block:: bash
@@ -38,17 +44,6 @@ Instructions
    user session, you would still be able to login with the ``<backup_user>``, and
    proceed with the maintenance.
 
-   .. warning::
-
-      The following guide can potentially lock you out of your computer.
-      You should be aware of these risks, as it is recommended to first use
-      the instructions below on a secondary computer, or after a full
-      backup.
-
-      You might lose access to your data after configuring `PAM
-      modules <https://www.man7.org/linux/man-pages/man8/pam.8.html>`__.
-
-
 2. **Install** ``libpam-u2f``
 
    On Ubuntu 24.04 it is possible to download directly ``libpam-u2f`` from the official repos
@@ -58,8 +53,6 @@ Instructions
       $ sudo apt install libpam-u2f
 
    .. note::
-
-      Click for more options
 
       -  Alternatively you can build ``libpam-u2f`` from
          `Git <https://github.com/phoeagon/pam-u2f>`__.
@@ -86,26 +79,28 @@ Instructions
 
       $ mkdir ~/.config/Nitrokey
 
-   And plug your Nitrokey.
-
-   Once done with the preparation, we can start to configure the computer to use the Nitrokey for 2nd factor authentication at login and ``sudo``.
-
 4. **Generate the U2F config file**
 
-   To generate the configuration file we will use the ``pamu2fcfg`` utility that comes with the ``libpam-u2f``. For convenience, we will directly write the output of the utility to the ``u2f_keys`` file under ``.config/Nitrokey``. First plug your Nitrokey (if you did not already), and enter the following command:
+   To generate the configuration file we will use the ``pamu2fcfg`` utility. First plug your Nitrokey (if you did not already), and enter the following command:
 
    .. code-block:: bash
 
       $ pamu2fcfg > ~/.config/Nitrokey/u2f_keys
 
-   Once you run the command above, you will need to touch the device while it flashes. Once done, ``pamu2fcfg`` will append its output the ``u2f_keys`` in the following format:
+   Once you run the command above, you will need to touch the device while it flashes. Once done, ``pamu2fcfg`` will append its output the ``u2f_keys`` in the format:
 
    .. code-block:: bash
 
-      <username>:Zx...mw,04...0a
+      <username>:KeyHandle,PublicKey,flags
 
-   Note, the output will be much longer, but sensitive parts have been removed here. For better security, and once the config file generated, we will move the ``.config/Nitrokey`` directory under the ``etc/``
-   directory with this command:
+   This will look something like the following:
+   
+   .. code-block:: bash
+
+      nitrouser:fS6vQ9uWa0VizcczyZ/bvk5kcQJkIJOC/21/e7dXFe/fnONSL705EkeiUpZpL/3seAWL/qW4/mqb0/WtiZoP/NOLTRM4EEAg1ANLsfYgSzRd/AjsW3z8kJwgckbvwDUyB90ByR09XtBhuE41vMsEk6J+9CS0+ZuPSB0KXRG7z2yZpQLldjE/ijsdIdd8Ct2oXSiZ/zTb/t5kRafNJVkp=,Oo4U9XvIhI9r0WNnvoMwG5/pbgwYd4GMCYEinhWcsI2hKUebYj92JOxDsSa3zd2A9OB0ofXgB16FD2naev3YmLch==,es256,+presence
+
+   Note, this output was not generated directly by ``pamu2fcfg`` and contains no sensitive information. It is purely meant to show the expected format and length of the output.
+   For better security, after the config file generated, we will move the ``.config/Nitrokey`` directory under the ``etc/`` directory with this command:
 
    .. code-block:: bash
 
@@ -144,8 +139,7 @@ Instructions
 
    .. code-block:: bash
 
-      $ cd /etc/pam.d
-      $ sudo $editor common-auth
+      $ sudo $EDITOR /etc/pam.d/common-auth
 
    And add the following lines at the top of the file:
 

--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -200,7 +200,7 @@ CLI Method
    .. code-block:: bash
 
       #Nitrokey FIDO2 config
-      auth    sufficient pam_u2f.so authfile=/etc/Nitrokey/u2f_keys cue [cue_prompt=Please touch the device.] prompt nouserok
+      auth    sufficient pam_u2f.so authfile=/etc/Nitrokey/u2f_keys cue [cue_prompt=Please touch the device.] prompt
 
    .. tip::
 
@@ -215,10 +215,6 @@ CLI Method
       -  If you would like to be prompted to touch the Nitrokey, ``cue``
          option will make ``pam_u2f`` print ``Please touch the device.``
          message. You can change the message in ``[cue_prompt=Please touch the device.]``.
-
-      -  `nouserok` will ensure that you can still login using the username and
-         password, you might want to remove this at some point once the setup
-         is working and you don't want regular username & password based logins.
 
    Once we modified the ``common-auth``, we can save and exit the file.
 

--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -49,22 +49,7 @@ Instructions
       modules <https://www.man7.org/linux/man-pages/man8/pam.8.html>`__.
 
 
-2. **Set up the** ``rules`` **to recognize the Nitrokey**
-
-   Under ``/etc/udev/rules.d`` download ``41-nitrokey.rules``
-
-   .. code-block:: bash
-
-      $ cd /etc/udev/rules.d/
-      $ sudo wget https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules
-
-   And restart ``udev`` service
-
-   .. code-block:: bash
-
-      $ sudo systemctl restart udev
-
-3. **Install** ``libpam-u2f``
+2. **Install** ``libpam-u2f``
 
    On Ubuntu 24.04 it is possible to download directly ``libpam-u2f`` from the official repos
 
@@ -93,7 +78,7 @@ Instructions
 
          /lib/x86_64-linux-gnu/security/pam_u2f.so: \ ELF 64-bit LSB shared object, x86-64, version 1 (SYSV),\ dynamically linked, BuildID[sha1]=1d55e1b11a97be2038c6a139579f6c0d91caedb1, stripped
 
-4. **Prepare the Directory**
+3. **Prepare the Directory**
 
    Create ``.config/Nitrokey/`` under your home directory
 
@@ -105,7 +90,7 @@ Instructions
 
    Once done with the preparation, we can start to configure the computer to use the Nitrokey for 2nd factor authentication at login and ``sudo``.
 
-5. **Generate the U2F config file**
+4. **Generate the U2F config file**
 
    To generate the configuration file we will use the ``pamu2fcfg`` utility that comes with the ``libpam-u2f``. For convenience, we will directly write the output of the utility to the ``u2f_keys`` file under ``.config/Nitrokey``. First plug your Nitrokey (if you did not already), and enter the following command:
 
@@ -143,7 +128,7 @@ Instructions
          directory in the next step, or not include the ``authfile`` option
          in the PAM configuration.
 
-6. **Backup**
+5. **Backup**
 
    This step is optional, however it is advised to have a backup Nitrokey in the case of loss, theft or destruction of your primary Nitrokey.
 
@@ -153,7 +138,7 @@ Instructions
 
       <username>:Zx...mw,04...0a:xB...fw,04...3f
 
-7. **Modify the Pluggable Authentication Module** ``PAM``
+6. **Modify the Pluggable Authentication Module** ``PAM``
 
    The final step is configure the PAM module files under ``/etc/pam.d/``. In this guide we will modify the ``common-auth`` file as it handles the authentication settings which are common to all services, but other options are possible. You can modify the file with the following command:
 
@@ -228,7 +213,7 @@ There are several PAM modules files that can be modified according to your needs
 Control Flags
 ''''''''''''''''''''''''
 
-In step 7 we have used the ``sufficient`` control flag to determine the behavior of the PAM module when the Nitrokey is plugged or not. However it is possible to change this behavior by using the following control flags:
+In step 6 we have used the ``sufficient`` control flag to determine the behavior of the PAM module when the Nitrokey is plugged or not. However it is possible to change this behavior by using the following control flags:
 
 -  ``required``: This is the most critical flag. The module result must
    be successful for authentication to continue. This flag can lock you

--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -24,39 +24,6 @@ Requirements
 Instructions
 ------------
 
-GUI Method
-''''''''''
-
-1. **In the lower left corner click on** ``Show Applications`` **and type settings in the search bar as following:**
-
-   .. figure:: images/desktop-login/fidou2f-1.png
-      :alt: img1
-
-2. **Scroll down in the right bar to** ``Users``
-
-   .. figure:: images/desktop-login/fidou2f-2.png
-      :alt: img2
-
-3. **In the left corner click on** ``Unlock`` **and that would prompt for your
-   password**
-
-   .. figure:: images/desktop-login/fidou2f-3.png
-      :alt: img3
-
-4. **Select** ``Administrator`` **and enter the user name and password of your
-   choice**
-
-   .. figure:: images/desktop-login/fidou2f-4.png
-      :alt: img4
-
-5. **Once you finish Step 4 you should be done**
-
-   .. figure:: images/desktop-login/fidou2f-5.png
-      :alt: img5
-
-CLI Method
-''''''''''
-
 1. **Create a backup user and give it root privileges**
 
    You can do so by using these commands:

--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -71,21 +71,13 @@ Instructions
 
          /lib/x86_64-linux-gnu/security/pam_u2f.so: \ ELF 64-bit LSB shared object, x86-64, version 1 (SYSV),\ dynamically linked, BuildID[sha1]=1d55e1b11a97be2038c6a139579f6c0d91caedb1, stripped
 
-3. **Prepare the Directory**
-
-   Create ``.config/Nitrokey/`` under your home directory
-
-   .. code-block:: bash
-
-      $ mkdir ~/.config/Nitrokey
-
-4. **Generate the U2F config file**
+3. **Generate the U2F config file**
 
    To generate the configuration file we will use the ``pamu2fcfg`` utility. First plug your Nitrokey (if you did not already), and enter the following command:
 
    .. code-block:: bash
 
-      $ pamu2fcfg > ~/.config/Nitrokey/u2f_keys
+      $ pamu2fcfg > ~/u2f_keys
 
    Once you run the command above, you will need to touch the device while it flashes. Once done, ``pamu2fcfg`` will append its output the ``u2f_keys`` in the format:
 
@@ -100,15 +92,17 @@ Instructions
       nitrouser:fS6vQ9uWa0VizcczyZ/bvk5kcQJkIJOC/21/e7dXFe/fnONSL705EkeiUpZpL/3seAWL/qW4/mqb0/WtiZoP/NOLTRM4EEAg1ANLsfYgSzRd/AjsW3z8kJwgckbvwDUyB90ByR09XtBhuE41vMsEk6J+9CS0+ZuPSB0KXRG7z2yZpQLldjE/ijsdIdd8Ct2oXSiZ/zTb/t5kRafNJVkp=,Oo4U9XvIhI9r0WNnvoMwG5/pbgwYd4GMCYEinhWcsI2hKUebYj92JOxDsSa3zd2A9OB0ofXgB16FD2naev3YmLch==,es256,+presence
 
    Note, this output was not generated directly by ``pamu2fcfg`` and contains no sensitive information. It is purely meant to show the expected format and length of the output.
-   For better security, after the config file generated, we will move the ``.config/Nitrokey`` directory under the ``etc/`` directory with this command:
+   For better security, after the config file generated, we will move the generated file ``~/u2f_keys`` directory under the ``/etc/Nitrokey/`` directory and change the access permissions with these commands:
 
    .. code-block:: bash
 
-      $ sudo mv ~/.config/Nitrokey /etc
+      $ sudo mkdir /etc/Nitrokey
+      $ sudo mv ~/u2f_keys /etc/Nitrokey/
+      $ sudo chmod 644 /etc/Nitrokey/u2f_keys
 
    .. tip::
 
-      -  The file under ``.config/Nitrokey`` must be named ``u2f_keys``
+      -  The file must be named ``u2f_keys``
 
       -  It is recommended to first test the instructions with a single
          user. For this purpose the previous command takes the ``-u``
@@ -117,13 +111,13 @@ Instructions
          .. rstcheck: ignore-next-code-block
          .. code-block:: bash
 
-            $ pamu2fcfg -u <username> > ~/.config/Nitrokey/u2f_keys
+            $ pamu2fcfg -u <username> > ~/u2f_keys
 
       -  For individual user configuration you should point to the home
          directory in the next step, or not include the ``authfile`` option
          in the PAM configuration.
 
-5. **Backup**
+4. **Backup**
 
    This step is optional, however it is advised to have a backup Nitrokey in the case of loss, theft or destruction of your primary Nitrokey.
 
@@ -133,7 +127,7 @@ Instructions
 
       <username>:Zx...mw,04...0a:xB...fw,04...3f
 
-6. **Modify the Pluggable Authentication Module** ``PAM``
+5. **Modify the Pluggable Authentication Module** ``PAM``
 
    The final step is configure the PAM module files under ``/etc/pam.d/``. In this guide we will modify the ``common-auth`` file as it handles the authentication settings which are common to all services, but other options are possible. You can modify the file with the following command:
 
@@ -207,7 +201,7 @@ There are several PAM modules files that can be modified according to your needs
 Control Flags
 ''''''''''''''''''''''''
 
-In step 6 we have used the ``sufficient`` control flag to determine the behavior of the PAM module when the Nitrokey is plugged or not. However it is possible to change this behavior by using the following control flags:
+In step 5 we have used the ``sufficient`` control flag to determine the behavior of the PAM module when the Nitrokey is plugged or not. However it is possible to change this behavior by using the following control flags:
 
 -  ``required``: This is the most critical flag. The module result must
    be successful for authentication to continue. This flag can lock you

--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -98,18 +98,8 @@ Instructions
       -  The file must be named ``u2f_keys``
 
       -  It is recommended to first test the instructions with a single
-         user. For this purpose the previous command takes the ``-u``
-         option, to specify a user, like in the example below:
-
-         .. rstcheck: ignore-next-code-block
-         .. code-block:: bash
-
-            $ pamu2fcfg -u <username> > ~/u2f_keys
-
-      -  For individual user configuration you should point to the home
-         directory in the next step, or not include the ``authfile`` option
-         in the PAM configuration.
-
+         user. To configure multiple users, look under `Configuring more users <#configuring-more-users>`_.
+         
 4. **Backup**
 
    This step is optional, however it is advised to have a backup Nitrokey in the case of loss, theft or destruction of your primary Nitrokey.
@@ -248,6 +238,24 @@ In step 6 we have used the ``sufficient`` control flag to determine the behavior
       if smart card login is enforced and you used the ``required`` or. 
       ``requisite`` flags. See Troubleshooting for further info.
 
+Configuring more users
+----------------------
+
+After you tested the login with the original user and everything worked as expected
+you can, if you wish to, configure u2f login for other users. To do so, ``pamu2fcfg`` takes
+the ``-u <username>`` option, the output can be appended to the ``u2f_keys`` file like this:
+
+.. code-block:: bash
+
+   $ sudo pamu2fcfg -u <username >> /etc/Nitrokey/u2f_keys
+
+To add a backup key to this user, plug in your backup Nitrokey and do the same you did for the primary user:
+
+.. code-block:: bash
+
+   $ sudo pamu2fcfg -n >> /etc/Nitrokey/u2f_keys
+
+After that repeat this process for all the users you want to.
 
 Troubleshooting
 ---------------

--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -118,7 +118,7 @@ Instructions
    
 5. **Securing the config file**
 
-   For better security, after the config file generated, we will move the generated file ``~/u2f_keys`` directory to ``/etc/Nitrokey/`` and change the access permissions with these commands:
+   For better security, after the config file was generated, we will move the generated file ``~/u2f_keys`` to ``/etc/Nitrokey/`` and change the access permissions using these commands:
 
    .. code-block:: bash
 
@@ -128,7 +128,7 @@ Instructions
 
 6. **Modify the Pluggable Authentication Module** ``PAM``
 
-   The final step is configure the PAM module files under ``/etc/pam.d/``. In this guide we will modify the ``common-auth`` file as it handles the authentication settings which are common to all services, but other options are possible. You can modify the file with the following command:
+   The final step is to configure the PAM module files under ``/etc/pam.d/``. In this guide we will modify the ``common-auth`` file as it handles the authentication settings which are common to all services, but other options are possible. You can modify the file with the following command:
 
    .. code-block:: bash
 
@@ -241,7 +241,7 @@ In step 6 we have used the ``sufficient`` control flag to determine the behavior
 Configuring more users
 ----------------------
 
-After you tested the login with the original user and everything worked as expected
+After you tested the login with the original user and everything worked as expected,
 you can, if you wish to, configure u2f login for other users. To do so, ``pamu2fcfg`` takes
 the ``-u <username>`` option, the output can be appended to the ``u2f_keys`` file like this:
 
@@ -249,7 +249,7 @@ the ``-u <username>`` option, the output can be appended to the ``u2f_keys`` fil
 
    $ sudo pamu2fcfg -u <username >> /etc/Nitrokey/u2f_keys
 
-To add a backup key to this user, plug in your backup Nitrokey and do the same you did for the primary user:
+To add a backup Nitrokey to this user, plug in your backup Nitrokey and do the same you did for the primary user:
 
 .. code-block:: bash
 

--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -5,6 +5,18 @@ Desktop Login And Linux User Authentication
 
 .. contents:: :local:
 
+Introduction
+------------
+
+This guide will walk you through the configuration of Linux to use FIDO Universal 2nd Factor, i.e. FIDO U2F with ``libpam-u2f`` and compatible Nitrokeys.
+You will set up your Nitrokey as a second factor for authentication. This means you will need your usual login method (likely your password) and your Nitrokey to login.
+
+If you want to use your Nitrokey as an alternative login method instead (password OR Nitrokey), see `Alternative Authentication Method <#alternative-authentication-method>`__ after completing the main guide.
+
+If you want to login to you computer using `Nitrokey Pro
+2, <https://shop.nitrokey.com/shop/product/nk-pro-2-nitrokey-pro-2-3>`__ `Nitrokey Storage
+2 <https://www.nitrokey.com/files/doc/Nitrokey_Storage_factsheet.pdf>`__ and `Nitrokey Start <https://shop.nitrokey.com/shop/product/nk-sta-nitrokey-start-6>`__ you can visit the instructions available `here <../openpgp-card/desktop-login/pam.html>`_.
+
 .. warning::
 
    The following guide can potentially lock you out of your computer.
@@ -14,15 +26,6 @@ Desktop Login And Linux User Authentication
 
    You might lose access to your data after configuring `PAM
    modules <https://www.man7.org/linux/man-pages/man8/pam.8.html>`__.
-
-Introduction
-------------
-
-This guide will walk you through the configuration of Linux to use FIDO Universal 2nd Factor, i.e. FIDO U2F with ``libpam-u2f`` and compatible Nitrokeys.
-
-If you want to login to you computer using `Nitrokey Pro
-2, <https://shop.nitrokey.com/shop/product/nk-pro-2-nitrokey-pro-2-3>`__ `Nitrokey Storage
-2 <https://www.nitrokey.com/files/doc/Nitrokey_Storage_factsheet.pdf>`__ and `Nitrokey Start <https://shop.nitrokey.com/shop/product/nk-sta-nitrokey-start-6>`__ you can visit the instructions available `here <../openpgp-card/desktop-login/pam.html>`_.
 
 Requirements
 ------------
@@ -79,7 +82,7 @@ Instructions
 
       $ pamu2fcfg > ~/u2f_keys
 
-   Once you run the command above, you will need to touch the device while it flashes. Once done, ``pamu2fcfg`` will append its output the ``u2f_keys`` in the format:
+   Once you run the command above, you will need to touch the device while it flashes. Once done, ``pamu2fcfg`` will append its output the ``u2f_keys`` file in the format:
 
    .. code-block:: bash
 
@@ -92,7 +95,33 @@ Instructions
       nitrouser:fS6vQ9uWa0VizcczyZ/bvk5kcQJkIJOC/21/e7dXFe/fnONSL705EkeiUpZpL/3seAWL/qW4/mqb0/WtiZoP/NOLTRM4EEAg1ANLsfYgSzRd/AjsW3z8kJwgckbvwDUyB90ByR09XtBhuE41vMsEk6J+9CS0+ZuPSB0KXRG7z2yZpQLldjE/ijsdIdd8Ct2oXSiZ/zTb/t5kRafNJVkp=,Oo4U9XvIhI9r0WNnvoMwG5/pbgwYd4GMCYEinhWcsI2hKUebYj92JOxDsSa3zd2A9OB0ofXgB16FD2naev3YmLch==,es256,+presence
 
    Note, this output was not generated directly by ``pamu2fcfg`` and contains no sensitive information. It is purely meant to show the expected format and length of the output.
-   For better security, after the config file generated, we will move the generated file ``~/u2f_keys`` directory under the ``/etc/Nitrokey/`` directory and change the access permissions with these commands:
+
+   .. tip::
+
+      -  The file must be named ``u2f_keys``
+
+      -  It is recommended to first test the instructions with a single
+         user. Other users configuration will be added it section 7.
+         
+4. **Setting up a backup Nitrokey**
+
+   This step is optional, however it is advised to have a second Nitrokey as backup in the case of loss, theft or destruction of your primary Nitrokey.
+
+   To set up a backup key, repeat the procedure above, and use ``pamu2fcfg -n`` like this:
+
+   .. code-block:: bash
+
+      $ pamu2fcfg -n >> ~/u2f_keys
+
+   This will omit the ``<username>`` field, and the output is appended to the line with your ``<username>``, this will look something like this:
+   
+   .. code-block:: bash
+
+      <username>:Zx...mw,04...0a:xB...fw,es256,+presence:04...3f,es256,+presence
+   
+5. **Securing the config file**
+
+   For better security, after the config file was generated, we will move the generated file ``~/u2f_keys`` to ``/etc/Nitrokey/`` and change the access permissions using these commands:
 
    .. code-block:: bash
 
@@ -100,42 +129,19 @@ Instructions
       $ sudo mv ~/u2f_keys /etc/Nitrokey/
       $ sudo chmod 644 /etc/Nitrokey/u2f_keys
 
-   .. tip::
+6. **Modify the Pluggable Authentication Module** ``PAM``
 
-      -  The file must be named ``u2f_keys``
+   Configure the PAM module files under ``/etc/pam.d/``.
+   This is a testing phase -  step 8 will enforce the configuration once you confirm it works.
 
-      -  It is recommended to first test the instructions with a single
-         user. For this purpose the previous command takes the ``-u``
-         option, to specify a user, like in the example below:
-
-         .. rstcheck: ignore-next-code-block
-         .. code-block:: bash
-
-            $ pamu2fcfg -u <username> > ~/u2f_keys
-
-      -  For individual user configuration you should point to the home
-         directory in the next step, or not include the ``authfile`` option
-         in the PAM configuration.
-
-4. **Backup**
-
-   This step is optional, however it is advised to have a backup Nitrokey in the case of loss, theft or destruction of your primary Nitrokey.
-
-   To set up a backup key, repeat the procedure above, and use ``pamu2fcfg -n``. This will omit the ``<username>`` field, and the output can be appended to the line with your ``<username>`` like this:
+   In this guide we will modify the ``common-auth`` file as it handles the authentication settings which are common to all services, other options are described in `PAM Modules <#pam-modules>`__.
+   You can modify the file with the following command:
 
    .. code-block:: bash
 
-      <username>:Zx...mw,04...0a:xB...fw,04...3f
+      $ sudo editor /etc/pam.d/common-auth
 
-5. **Modify the Pluggable Authentication Module** ``PAM``
-
-   The final step is configure the PAM module files under ``/etc/pam.d/``. In this guide we will modify the ``common-auth`` file as it handles the authentication settings which are common to all services, but other options are possible. You can modify the file with the following command:
-
-   .. code-block:: bash
-
-      $ sudo $EDITOR /etc/pam.d/common-auth
-
-   And add the following lines at the top of the file:
+   Add the following line at the **bottom** of the file:
 
    .. code-block:: bash
 
@@ -144,11 +150,13 @@ Instructions
 
    .. tip::
 
+      -  We are using sufficient for testing and will change to required in Step 8.
+
       -  Since we are using Central Authentication Mapping, we need to tell
          ``pam_u2f`` the location of the file to use with the ``authfile``
          option.
 
-      -  If you often forget to insert the key, ``prompt`` option make
+      -  If you often forget to insert the key, ``prompt`` option makes
          ``pam_u2f`` print ``Insert your U2F device, then press ENTER.``
          and give you a chance to insert the Nitrokey.
 
@@ -156,9 +164,19 @@ Instructions
          option will make ``pam_u2f`` print ``Please touch the device.``
          message. You can change the message in ``[cue_prompt=Please touch the device.]``.
 
+   .. note::
+      
+      **Why bottom placement?** PAM processes modules from top to bottom. Placing the U2F 
+      configuration at the bottom ensures password authentication is checked first, creating 
+      a second-factor workflow (password + U2F).
+      
+      For alternative authentication options (password OR Nitrokey) and detailed explanations 
+      of how line position and control flags affect authentication, see 
+      `Alternative Authentication Method <#alternative-authentication-method>`__.
+
    Once we modified the ``common-auth``, we can save and exit the file.
 
-   You can test the configuration by typing ``sudo ls`` in the terminal. You should be prompted the message ``Please touch the device.`` and have a similar output on the terminal:
+   You can test the configuration by typing ``sudo ls`` in the terminal. After typing in your password you should be prompted with the message ``Please touch the device.`` and have a similar output on the terminal:
 
    .. code-block:: bash
 
@@ -170,56 +188,157 @@ Instructions
    .. figure:: images/desktop-login/u2f-fido-pam-2.png
       :alt: img6
 
-Usage
------
+7. **Setting up multiple users**
 
-After the PAM module modification, you will be able to test your configuration right away, but it is recommended to reboot your computer, and unplug/replug the Nitrokey.
+   After confirming that authentication using your Nitrokey did work, you can set up the U2F config file for the other users on your system.
 
-Once you have properly tested the instructions in this guide (and set up a backup), it is recommended to use either the ``required`` or the ``requisite`` control flag instead of ``sufficient``.
+   .. warning::
 
-The flags ``required`` and ``requisite`` provide a tighter access control, and will make the Nitrokey necessary to login, and/or use the configured service.
+      Should you not set up all users in the U2F config file and continue with enforcing
+      Nitrokey authentication in step 8, you will not be able to log in with any not configured user!
 
-If you need more information about Control Flags in the ``PAM``
-configuration line, you may see the last section of this guide to understand the difference, and the implications of using each of them.
+   To configure u2f for multiple users, ``pamu2fcfg`` takes
+   the ``-u <username>`` option, the output can be appended to the ``u2f_keys`` file like this:
+
+   .. rstcheck: ignore-next-code-block
+   .. code-block:: bash
+
+      $ sudo pamu2fcfg -u <username> >> /etc/Nitrokey/u2f_keys
+
+   To add a backup Nitrokey to this user, plug in your backup Nitrokey and do the same you did for the primary user:
+
+   .. code-block:: bash
+
+      $ sudo pamu2fcfg -n >> /etc/Nitrokey/u2f_keys
+
+   After that repeat this process for all the users on your system.
+
+8. **Enforcing Nitrokey second factor authentication**
+
+   You may have noticed that authenticating with the Nitrokey was not enforced yet. After confirming that authentication using the Nitrokey does work, we can enforce 
+   it by changing the ``sufficient`` flag to ``required``.
+
+   .. warning::
+
+      Before continuing with this step, make sure you have:
+
+      -  Tested that authentication with the Nitrokey does indeed work,
+         otherwise you can lose access to your computer.
+
+      -  Set up a backup Nitrokey. Otherwise if you lose or break your Nitrokey,
+         you will lose access to your computer!
+
+      Proceed with care!
+
+   To do so you need to edit the ``PAM`` configuration file:
+
+   .. code-block:: bash
+
+      $ sudo editor /etc/pam.d/common-auth
+
+   In the line you added earlier at the bottom of the file change the word ``sufficient`` to ``required``. It should look like this:
+
+   .. code-block:: bash
+
+      #Nitrokey config
+      auth    required pam_u2f.so authfile=/etc/Nitrokey/u2f_keys cue [cue_prompt=Please touch the device.] prompt
+
+After completing the setup, it is recommended to reboot your computer and unplug/replug the Nitrokey.
+
+Alternative Authentication Method
+---------------------------------
+
+If you prefer to use your Nitrokey as an alternative to your password (password OR Nitrokey), you can configure this instead:
+
+**Configuration Steps:**
+
+1. Move the PAM configuration line to the **top** of ``/etc/pam.d/common-auth`` (before other auth modules)
+2. Keep the ``sufficient`` control flag
+
+This allows authentication with either factor alone. Note that this provides less security than second-factor authentication.
+
+**Understanding Authentication Modes**
+
+The combination of line position and control flag determines your authentication mode:
+
+.. list-table:: Authentication Modes
+   :width: 100%
+   :header-rows: 1
+
+   * - Position
+     - Control Flag
+     - Authentication Mode
+     - Use Case
+
+   * - Bottom (after pam_unix)
+     - ``sufficient``
+     - Second factor (testing)
+     - Safe testing phase
+
+   * - Bottom (after pam_unix)
+     - ``required``
+     - Second factor (enforced)
+     - Production security (main guide)
+
+   * - Top (before pam_unix)
+     - ``sufficient``
+     - Alternative factor
+     - Convenience (password OR key)
+
+**How PAM Works:**
+
+PAM processes modules sequentially from top to bottom. The control flag determines how 
+success or failure affects the overall authentication:
+
+- ``sufficient``: Success completes authentication; failure is ignored if other modules succeed
+- ``required``: Success is mandatory; failure causes overall authentication failure
+
+**What This Means For You:**
+
+*Alternative authentication (top + sufficient):*
+
+- You can log in with your password **OR** your Nitrokey alone
+- If authentication with the Nitrokey succeeds, no password is required
+- If the Nitrokey authentication fails or is skipped, the password will still work
+- This is more convenient but less secure than second-factor authentication
+
+*Security implications:*
+
+- An attacker with your password can log in without your Nitrokey
+- An attacker with physical access to your Nitrokey can log in without your password
+- Use this only if convenience is more important than maximum security
+
+For detailed explanations of control flags and their implications, see `Control Flags <#control-flags>`__.
 
 PAM Modules
-''''''''''''''''''''''''
+-----------
 
 There are several PAM modules files that can be modified according to your needs:
 
 -  By modifying ``/etc/pam.d/common-auth`` file, you will be able to use
    you Nitrokey for 2nd factor authentication for graphic login and
-   ``sudo``. Note: ``common-auth`` should be modified by adding the
-   additional configuration line at the end of the file.
+   ``sudo``.
 
--  If you wish to use FIDO U2F authentication solely for Gnome’s graphic
-   login, you might prefer to modify the\ ``/etc/pam.d/gdm-password``
+-  If you wish to use FIDO U2F authentication solely for Gnome's graphic
+   login, you might prefer to modify the ``/etc/pam.d/gdm-password``
 
 -  Alternatively you can just modify the ``/etc/pam.d/sudo`` file if you
    wish to use FIDO U2F when using the ``sudo`` command.
 
 Control Flags
-''''''''''''''''''''''''
+-------------
 
-In step 5 we have used the ``sufficient`` control flag to determine the behavior of the PAM module when the Nitrokey is plugged or not. However it is possible to change this behavior by using the following control flags:
+The control flag determines how the PAM module behaves when authentication succeeds or fails. In step 6 we used the ``sufficient`` flag for testing, then changed to ``required`` for enforcement.
 
--  ``required``: This is the most critical flag. The module result must
-   be successful for authentication to continue. This flag can lock you
-   out of your computer if you do not have access to the Nitrokey.
+The available control flags are:
 
--  ``requisite``: Similar to ``required`` however, in the case where a
-   specific module returns a failure, control is directly returned to
-   the application, or to the superior PAM stack. This flag can also
-   lock you out of your computer if you do not have access to the
-   Nitrokey.
+-  ``required``: The module result must be successful for authentication to continue. This is the most critical flag and can lock you out of your computer if you do not have access to the Nitrokey.
 
--  ``sufficient``: The module result is ignored if it fails. The
-   ``sufficient`` flag considered to be safe for testing purposes.
+-  ``requisite``: Similar to ``required`` however, in the case where a specific module returns a failure, control is directly returned to the application, or to the superior PAM stack. This flag can also lock you out of your computer if you do not have access to the Nitrokey.
 
--  ``optional``: The success or failure of this module is only important
-   if it is the only module in the stack associated with this
-   service+type. The ``optional`` flag is considered to be safe to use
-   for testing purposes.
+-  ``sufficient``: The module result is ignored if it fails. In case of success, control is directly returned to the application, or to the superior PAM stack. This means no other PAM modules will be executed. The ``sufficient`` flag is considered safe for testing purposes.
+
+-  ``optional``: The success or failure of this module is only important if it is the only module in the stack associated with this service+type. The ``optional`` flag is considered safe to use for testing purposes.
 
 .. warning::
 
@@ -236,9 +355,8 @@ In step 5 we have used the ``sufficient`` control flag to determine the behavior
       ``requisite`` flags.
 
    -  You might also lose the ability to log in using Gnome Display manager
-      if smart card login is enforced and you used the ``required`` or. 
+      if smart card login is enforced and you used the ``required`` or
       ``requisite`` flags. See Troubleshooting for further info.
-
 
 Troubleshooting
 ---------------

--- a/source/components/nitrokeys/features/u2f/desktop-login.rst
+++ b/source/components/nitrokeys/features/u2f/desktop-login.rst
@@ -5,10 +5,20 @@ Desktop Login And Linux User Authentication
 
 .. contents:: :local:
 
+.. warning::
+
+   The following guide can potentially lock you out of your computer.
+   You should be aware of these risks, as it is recommended to first use
+   the instructions below on a secondary computer, or after a full
+   backup.
+
+   You might lose access to your data after configuring `PAM
+   modules <https://www.man7.org/linux/man-pages/man8/pam.8.html>`__.
+
 Introduction
 ------------
 
-This guide will walk you through the configuration of Linux to use FIDO Universal 2nd Factor, i.e. FIDO U2F with ``libpam-u2f`` and Nitrokey FIDO2.
+This guide will walk you through the configuration of Linux to use FIDO Universal 2nd Factor, i.e. FIDO U2F with ``libpam-u2f`` and compatible Nitrokeys.
 
 If you want to login to you computer using `Nitrokey Pro
 2, <https://shop.nitrokey.com/shop/product/nk-pro-2-nitrokey-pro-2-3>`__ `Nitrokey Storage
@@ -17,49 +27,12 @@ If you want to login to you computer using `Nitrokey Pro
 Requirements
 ------------
 
--  Ubuntu 20.04 with Gnome Display Manager.
-
--  A FIDO2 capable Nitrokey: see table ``Compatible Nitrokeys`` at the top of the page for reference.
+-  Ubuntu 24.04 with Gnome Display Manager (GDM).
 
 Instructions
 ------------
 
-GUI Method
-''''''''''
-
-1. **In the lower left corner click on** ``Show Applications`` **and type settings in the search bar as following:**
-
-   .. figure:: images/desktop-login/fidou2f-1.png
-      :alt: img1
-
-2. **Scroll down in the right bar to** ``Users``
-
-   .. figure:: images/desktop-login/fidou2f-2.png
-      :alt: img2
-
-3. **In the left corner click on** ``Unlock`` **and that would prompt for your
-   password**
-
-   .. figure:: images/desktop-login/fidou2f-3.png
-      :alt: img3
-
-4. **Select** ``Administrator`` **and enter the user name and password of your
-   choice**
-
-   .. figure:: images/desktop-login/fidou2f-4.png
-      :alt: img4
-
-5. **Once you finish Step 4 you should be done**
-
-   .. figure:: images/desktop-login/fidou2f-5.png
-      :alt: img5
-
-CLI Method
-''''''''''
-
 1. **Create a backup user and give it root privileges**
-
-   You can do so by using these commands:
 
    .. rstcheck: ignore-next-code-block
    .. code-block:: bash
@@ -71,43 +44,15 @@ CLI Method
    user session, you would still be able to login with the ``<backup_user>``, and
    proceed with the maintenance.
 
-   .. warning::
+2. **Install** ``libpam-u2f``
 
-      The following guide can potentially lock you out of your computer.
-      You should be aware of these risks, as it is recommended to first use
-      the instructions below on a secondary computer, or after a full
-      backup.
-
-      You might lose access to your data after configuring `PAM
-      modules <https://www.man7.org/linux/man-pages/man8/pam.8.html>`__.
-
-
-2. **Set up the** ``rules`` **to recognize the Nitrokey FIDO2**
-
-   Under ``/etc/udev/rules.d`` download ``41-nitrokey.rules``
-
-   .. code-block:: bash
-
-      $ cd /etc/udev/rules.d/
-      $ sudo wget https://raw.githubusercontent.com/Nitrokey/nitrokey-udev-rules/main/41-nitrokey.rules
-
-   And restart ``udev`` service
-
-   .. code-block:: bash
-
-      $ sudo systemctl restart udev
-
-3. **Install** ``libpam-u2f``
-
-   On Ubuntu 20.04 it is possible to download directly ``libpam-u2f`` from the official repos
+   On Ubuntu 24.04 it is possible to download directly ``libpam-u2f`` from the official repos
 
    .. code-block:: bash
 
       $ sudo apt install libpam-u2f
 
    .. note::
-
-      Click for more options
 
       -  Alternatively you can build ``libpam-u2f`` from
          `Git <https://github.com/phoeagon/pam-u2f>`__.
@@ -126,42 +71,38 @@ CLI Method
 
          /lib/x86_64-linux-gnu/security/pam_u2f.so: \ ELF 64-bit LSB shared object, x86-64, version 1 (SYSV),\ dynamically linked, BuildID[sha1]=1d55e1b11a97be2038c6a139579f6c0d91caedb1, stripped
 
-4. **Prepare the Directory**
+3. **Generate the U2F config file**
 
-   Create ``.config/Nitrokey/`` under your home directory
-
-   .. code-block:: bash
-
-      $ mkdir ~/.config/Nitrokey
-
-   And plug your Nitrokey FIDO2.
-
-   Once done with the preparation, we can start to configure the computer to use the Nitrokey FIDO2 for 2nd factor authentication at login and ``sudo``.
-
-5. **Generate the U2F config file**
-
-   To generate the configuration file we will use the ``pamu2fcfg`` utility that comes with the ``libpam-u2f``. For convenience, we will directly write the output of the utility to the ``u2f_keys`` file under ``.config/Nitrokey``. First plug your Nitrokey FIDO2 (if you did not already), and enter the following command:
+   To generate the configuration file we will use the ``pamu2fcfg`` utility. First plug your Nitrokey (if you did not already), and enter the following command:
 
    .. code-block:: bash
 
-      $ pamu2fcfg > ~/.config/Nitrokey/u2f_keys
+      $ pamu2fcfg > ~/u2f_keys
 
-   Once you run the command above, you will need to touch the device while it flashes. Once done, ``pamu2fcfg`` will append its output the ``u2f_keys`` in the following format:
-
-   .. code-block:: bash
-
-      <username>:Zx...mw,04...0a
-
-   Note, the output will be much longer, but sensitive parts have been removed here. For better security, and once the config file generated, we will move the ``.config/Nitrokey`` directory under the ``etc/``
-   directory with this command:
+   Once you run the command above, you will need to touch the device while it flashes. Once done, ``pamu2fcfg`` will append its output the ``u2f_keys`` in the format:
 
    .. code-block:: bash
 
-      $ sudo mv ~/.config/Nitrokey /etc
+      <username>:KeyHandle,PublicKey,flags
+
+   This will look something like the following:
+   
+   .. code-block:: bash
+
+      nitrouser:fS6vQ9uWa0VizcczyZ/bvk5kcQJkIJOC/21/e7dXFe/fnONSL705EkeiUpZpL/3seAWL/qW4/mqb0/WtiZoP/NOLTRM4EEAg1ANLsfYgSzRd/AjsW3z8kJwgckbvwDUyB90ByR09XtBhuE41vMsEk6J+9CS0+ZuPSB0KXRG7z2yZpQLldjE/ijsdIdd8Ct2oXSiZ/zTb/t5kRafNJVkp=,Oo4U9XvIhI9r0WNnvoMwG5/pbgwYd4GMCYEinhWcsI2hKUebYj92JOxDsSa3zd2A9OB0ofXgB16FD2naev3YmLch==,es256,+presence
+
+   Note, this output was not generated directly by ``pamu2fcfg`` and contains no sensitive information. It is purely meant to show the expected format and length of the output.
+   For better security, after the config file generated, we will move the generated file ``~/u2f_keys`` directory under the ``/etc/Nitrokey/`` directory and change the access permissions with these commands:
+
+   .. code-block:: bash
+
+      $ sudo mkdir /etc/Nitrokey
+      $ sudo mv ~/u2f_keys /etc/Nitrokey/
+      $ sudo chmod 644 /etc/Nitrokey/u2f_keys
 
    .. tip::
 
-      -  The file under ``.config/Nitrokey`` must be named ``u2f_keys``
+      -  The file must be named ``u2f_keys``
 
       -  It is recommended to first test the instructions with a single
          user. For this purpose the previous command takes the ``-u``
@@ -170,15 +111,15 @@ CLI Method
          .. rstcheck: ignore-next-code-block
          .. code-block:: bash
 
-            $ pamu2fcfg -u <username> > ~/.config/Nitrokey/u2f_keys
+            $ pamu2fcfg -u <username> > ~/u2f_keys
 
       -  For individual user configuration you should point to the home
          directory in the next step, or not include the ``authfile`` option
          in the PAM configuration.
 
-6. **Backup**
+4. **Backup**
 
-   This step is optional, however it is advised to have a backup Nitrokey in the case of loss, theft or destruction of your Nitrokey FIDO.
+   This step is optional, however it is advised to have a backup Nitrokey in the case of loss, theft or destruction of your primary Nitrokey.
 
    To set up a backup key, repeat the procedure above, and use ``pamu2fcfg -n``. This will omit the ``<username>`` field, and the output can be appended to the line with your ``<username>`` like this:
 
@@ -186,20 +127,19 @@ CLI Method
 
       <username>:Zx...mw,04...0a:xB...fw,04...3f
 
-7. **Modify the Pluggable Authentication Module** ``PAM``
+5. **Modify the Pluggable Authentication Module** ``PAM``
 
    The final step is configure the PAM module files under ``/etc/pam.d/``. In this guide we will modify the ``common-auth`` file as it handles the authentication settings which are common to all services, but other options are possible. You can modify the file with the following command:
 
    .. code-block:: bash
 
-      $ cd /etc/pam.d
-      $ sudo $editor common-auth
+      $ sudo $EDITOR /etc/pam.d/common-auth
 
    And add the following lines at the top of the file:
 
    .. code-block:: bash
 
-      #Nitrokey FIDO2 config
+      #Nitrokey config
       auth    sufficient pam_u2f.so authfile=/etc/Nitrokey/u2f_keys cue [cue_prompt=Please touch the device.] prompt
 
    .. tip::
@@ -225,7 +165,7 @@ CLI Method
       nitrouser@nitrouser:~$ sudo ls
       [sudo] password for nitrouser:  Please touch the device.
 
-   You can also test your configuration by logging out of the user session and logging back. A similar screen should be displayed once you you unplug/replug yout Nitrokey FIDO2 and type your password:
+   You can also test your configuration by logging out of the user session and logging back. A similar screen should be displayed once you you unplug/replug yout Nitrokey and type your password:
 
    .. figure:: images/desktop-login/u2f-fido-pam-2.png
       :alt: img6
@@ -233,11 +173,11 @@ CLI Method
 Usage
 -----
 
-After the PAM module modification, you will be able to test your configuration right away, but it is recommended to reboot your computer, and unplug/replug the Nitrokey FIDO2.
+After the PAM module modification, you will be able to test your configuration right away, but it is recommended to reboot your computer, and unplug/replug the Nitrokey.
 
 Once you have properly tested the instructions in this guide (and set up a backup), it is recommended to use either the ``required`` or the ``requisite`` control flag instead of ``sufficient``.
 
-The flags ``required`` and ``requisite`` provide a tighter access control, and will make the Nitrokey FIDO2 necessary to login, and/or use the configured service.
+The flags ``required`` and ``requisite`` provide a tighter access control, and will make the Nitrokey necessary to login, and/or use the configured service.
 
 If you need more information about Control Flags in the ``PAM``
 configuration line, you may see the last section of this guide to understand the difference, and the implications of using each of them.
@@ -248,7 +188,7 @@ PAM Modules
 There are several PAM modules files that can be modified according to your needs:
 
 -  By modifying ``/etc/pam.d/common-auth`` file, you will be able to use
-   you Nitrokey FIDO for 2nd factor authentication for graphic login and
+   you Nitrokey for 2nd factor authentication for graphic login and
    ``sudo``. Note: ``common-auth`` should be modified by adding the
    additional configuration line at the end of the file.
 
@@ -261,7 +201,7 @@ There are several PAM modules files that can be modified according to your needs
 Control Flags
 ''''''''''''''''''''''''
 
-In step 7 we have used the ``sufficient`` control flag to determine the behavior of the PAM module when the Nitrokey is plugged or not. However it is possible to change this behavior by using the following control flags:
+In step 5 we have used the ``sufficient`` control flag to determine the behavior of the PAM module when the Nitrokey is plugged or not. However it is possible to change this behavior by using the following control flags:
 
 -  ``required``: This is the most critical flag. The module result must
    be successful for authentication to continue. This flag can lock you
@@ -285,7 +225,7 @@ In step 7 we have used the ``sufficient`` control flag to determine the behavior
 
    -  If ``required`` or ``requisite`` is set, the failure of U2F
       authentication will cause a failure of the overall authentication.
-      Failure will occur when the configured Nitrokey FIDO is not
+      Failure will occur when the configured Nitrokey is not
       plugged, lost or destroyed.
 
    -  You will lose access to your computer if you mis-configured the
@@ -294,3 +234,23 @@ In step 7 we have used the ``sufficient`` control flag to determine the behavior
    -  You will also lose the ability to use ``sudo`` if you set up
       Central Authentication Mapping *and* used the ``required`` or
       ``requisite`` flags.
+
+   -  You might also lose the ability to log in using Gnome Display manager
+      if smart card login is enforced and you used the ``required`` or. 
+      ``requisite`` flags. See Troubleshooting for further info.
+
+
+Troubleshooting
+---------------
+
+Issues logging into user account using GDM
+''''''''''''''''''''''''''''''''''''''''''
+
+In some cases, for example if you have `opencs-pkcs11` installed, Gnome Display Manager (GDM) can
+default to enforcing smart card login as soon as any smart card (like your Nitrokey) is plugged in, even if no smart card has ever been configured. 
+This can prevent you from logging in to your user account using u2f. If you have set the ``sufficient`` control flag,
+unplug all smart cards and log in using your password. To turn off smart card enforcing run the following command:
+
+.. code-block:: bash
+
+   $ sudo -u gdm env -u XDG_RUNTIME_DIR -u DISPLAY DCONF_PROFILE=gdm dbus-run-session gsettings set org.gnome.login-screen enable-smartcard-authentication false


### PR DESCRIPTION
remove `nouserok`: appears to be ignored on Ubuntu. Login with password still possible without it if `sufficient` control flag is used.

fixes #278 

Added troubleshooting guide for issues caused by gdm when certain pkcs packages are installed.
General updates and cleanup.

Change entire structure of the guide to better explain different authentication methods.