### PR TITLE
Increase timeout for nightly linkcheck

### DIFF
--- a/linkcheckerrc_nightly
+++ b/linkcheckerrc_nightly
@@ -5,6 +5,7 @@ ignore=
 
 [checking]
 threads=1
+timeout=120
 
 [output]
 warnings=0


### PR DESCRIPTION
This PR increases the timeout for the nightly linkcheck CI job, from the default `60` seconds to `120` seconds. The CI job sometimes fails as some link targets take longer to respond.