### PR TITLE
Remove broken hyperlink and unsued build option

### DIFF
--- a/source/components/nitrokeys/features/hsm/n-of-m-schemes.rst
+++ b/source/components/nitrokeys/features/hsm/n-of-m-schemes.rst
@@ -15,25 +15,13 @@ Nitrokey HSM's Secure Key Backup and Restore:
 
 .. raw:: html
 
- <a href="https://asciinema.org/a/152957" target="_blank"><img src="https://asciinema.org/a/152957.svg" /></a>
-
-
-.. only:: comment
-
-   <script id="asciicast-152957" src="https://asciinema.org/a/152957.js" async></script>
-.. only:: comment
-
- <iframe width="560" height="315" src="https://asciinema.org/a/152957" frameborder="0" allowfullscreen></iframe>
+   <a href="https://asciinema.org/a/152957" target="_blank"><img src="https://asciinema.org/a/152957.svg" /></a>
 
 Nitrokey HSM's M-of-N Threshold Scheme:
 
 .. raw:: html
 
- <a href="https://asciinema.org/a/153021" target="_blank"><img src="https://asciinema.org/a/153021.svg" /></a>
-
-.. only:: comment
-
-   <iframe width="560" height="315" src="https://asciinema.org/a/153021" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+   <a href="https://asciinema.org/a/153021" target="_blank"><img src="https://asciinema.org/a/153021.svg" /></a>
 
 N-of-m for public key authentication
 ''''''''''''''''''''''''''''''''''''

--- a/source/components/nitrokeys/features/openpgp-card/hard-disk-encryption/index.rst
+++ b/source/components/nitrokeys/features/openpgp-card/hard-disk-encryption/index.rst
@@ -38,8 +38,6 @@ Follow these steps to use the program with `Nitrokey Storage
    a keyfile on the Nitrokey which theoretically could be stolen by a
    compromised host, since the *Private Data Object 1* is not protected by the Nitrokey's PIN.
 
-Note: `Aloaha Crypt <https://www.aloaha.com/aloaha-crypt-disk/>`__ is based on TrueCrypt/VeraCrypt but without the described security limitation.
-
 Hard Disk Encryption on GNU+Linux with LUKS/dm-crypt
 ----------------------------------------------------
 


### PR DESCRIPTION
This PR removes a hyperlink to a discontinued product and removes a build option we actual never use, while fixing the syntax on the HTML version.