### PR TITLE
Trailing character checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,24 @@ jobs:
         run: make venv
       - name: Syntax check
         run: make check-syntax
+  check-trailing-whitespaces:
+    name: Check trailing whitespaces
+    runs-on: ubuntu-latest
+    container: python:3.11
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Trailing whitespaces check
+        run: make check-trailing-whitespaces
+  check-trailing-tabs:
+    name: Check trailing tabs
+    runs-on: ubuntu-latest
+    container: python:3.11
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Trailing whitespaces check
+        run: make check-trailing-tabs
   check-hyperlinks:
     name: Check hyperlinks
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,21 @@ venv: $(NITROKEY_SDK_PY)
 check-syntax: venv
 	venv/bin/rstcheck --config rstcheck.toml --recursive source
 
+.PHONY: check-trailing-characters
+check-trailing-characters: check-trailing-whitespaces check-trailing-tabs
+
+.PHONY: check-trailing-whitespaces
+check-trailing-whitespaces:
+	grep -RIn --include='*.rst' -P '\s+$$' source/ ; \
+	rc=$$? ; \
+	if [ "$$rc" = 1 ]; then exit 0; elif [ "$$rc" = 0 ]; then exit 1; else exit "$$rc"; fi
+
+.PHONY: check-trailing-tabs
+check-trailing-tabs:
+	grep -RIn --include='*.rst' -P '\t+$$' source/ ; \
+	rc=$$? ; \
+	if [ "$$rc" = 1 ]; then exit 0; elif [ "$$rc" = 0 ]; then exit 1; else exit "$$rc"; fi
+
 .PHONY: check-hyperlinks
 check-hyperlinks: venv docs
 	venv/bin/linkchecker -f linkcheckerrc dist/en/index.html

--- a/source/components/nethsm/getting-started.rst
+++ b/source/components/nethsm/getting-started.rst
@@ -12,7 +12,7 @@ Please follow this process closely to verify that it has arrived safely.
 
 1. Check the two security seals on the box for any damage, peeling, or other alterations.
    One seal is located on the top of the box and one on the bottom.
-   
+
    .. figure:: ./images/sealing/Package_top.jpg
       :scale: 15
       :alt: Seal on the top of the box


### PR DESCRIPTION
This PR adds checks for trailing whitespace and tab characters.

- Three new Makefile targets: `check-trailing-whitespaces`, `check-trailing-tabs`, and `check-trailing-characters`.
- GitHub Actions workflow checks for whitespaces and tabs. Checks are separate jobs to make the origin of a failed pipeline directly obvious.
- Fix a trailing whitespace error.