### PR TITLE
Check mixed indentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,15 @@ jobs:
         uses: actions/checkout@v6
       - name: Trailing whitespaces check
         run: make check-trailing-tabs
+  check-mixed-indentation:
+    name: Check mixed indentation
+    runs-on: ubuntu-latest
+    container: python:3.11
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Mixed indentation check
+        run: make check-mixed-indentation
   check-hyperlinks:
     name: Check hyperlinks
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ check-trailing-tabs:
 	rc=$$? ; \
 	if [ "$$rc" = 1 ]; then exit 0; elif [ "$$rc" = 0 ]; then exit 1; else exit "$$rc"; fi
 
+.PHONY: check-mixed-indentation
+check-mixed-indentation:
+	grep -RIn --include='*.rst' -P '^(?:\t|\s+\t)' source/ ; \
+	rc=$$? ; \
+	if [ "$$rc" = 1 ]; then exit 0; elif [ "$$rc" = 0 ]; then exit 1; else exit "$$rc"; fi
+
 .PHONY: check-hyperlinks
 check-hyperlinks: venv docs
 	venv/bin/linkchecker -f linkcheckerrc dist/en/index.html


### PR DESCRIPTION
This PR adds a check for mixed indentation.

- Makefile target `check-mixed-indentation`.
- GitHub Actions workflow check for mixed indentation.

This test flags all lines that use tabs for indentation, incl. mixed ones with whitespaces.