### PR TITLE
Fix registry path and add registry login

### DIFF
--- a/source/components/nethsm/container/production-image.rst
+++ b/source/components/nethsm/container/production-image.rst
@@ -7,7 +7,8 @@ The NetHSM process can be executed with hardware-based separation (KVM) and devi
 The image is distributed as OCI image and can be run locally with a compatible executor such as Docker and Podman.
 
 The NetHSM production container is a product for paying customers only and can be purchased `here <https://www.nitrokey.com/contact>`__.
-The image can be obtained from Nitrokey NetHSM registry ``https://registry.git.nitrokey.com/distribution/nethsm>`` using the credentials provided after purchase.
+The image can be obtained from Nitrokey's NetHSM registry ``registry.git.nitrokey.com/distribution/nethsm/production``.
+Login credentials to the registry are provided after purchase and are to be used with `Docker login <https://docs.docker.com/reference/cli/docker/login/>`__ or `Podman login <https://docs.podman.io/en/latest/markdown/podman-login.1.html>`__.
 
 .. warning::
    The security of the NetHSM software container strongly depends on the platform's security.
@@ -107,12 +108,12 @@ The container can be executed as follows.
    .. tab:: Docker
       .. code-block:: bash
 
-         $ docker run -ti --rm -p 8443:8443 registry.git.nitrokey.com/distribution/nethsm:latest
+         $ docker run -ti --rm -p 8443:8443 registry.git.nitrokey.com/distribution/nethsm/production:latest
 
    .. tab:: Podman
       .. code-block:: bash
 
-         $ podman run -ti --rm -p 8443:8443 registry.git.nitrokey.com/distribution/nethsm:latest
+         $ podman run -ti --rm -p 8443:8443 registry.git.nitrokey.com/distribution/nethsm/production:latest
 
 This will run NetHSM as a Unix process inside the container and expose the REST API on the port `8443` via the HTTPS protocol.
 
@@ -137,12 +138,12 @@ The container can be executed as follows.
    .. tab:: Docker
       .. code-block:: bash
 
-         $ docker run -ti --rm -p 8443:8443 --device /dev/net/tun --device /dev/kvm --cap-add=NET_ADMIN -e "MODE=unikernel" registry.git.nitrokey.com/distribution/nethsm:latest
+         $ docker run -ti --rm -p 8443:8443 --device /dev/net/tun --device /dev/kvm --cap-add=NET_ADMIN -e "MODE=unikernel" registry.git.nitrokey.com/distribution/nethsm/production:latest
 
    .. tab:: Podman
       .. code-block:: bash
 
-         $ podman run -ti --rm -p 8443:8443 --device /dev/net/tun --device /dev/kvm --cap-add=NET_ADMIN -e "MODE=unikernel" registry.git.nitrokey.com/distribution/nethsm:latest
+         $ podman run -ti --rm -p 8443:8443 --device /dev/net/tun --device /dev/kvm --cap-add=NET_ADMIN -e "MODE=unikernel" registry.git.nitrokey.com/distribution/nethsm/production:latest
 
 This will run NetHSM as a unikernel inside a KVM virtual machine.
 The container will expose the REST API, via the HTTPS protocol, on the interface `tap200` with the IP address `192.168.1.100` and port `8443`.


### PR DESCRIPTION
This PR fixes the path to the NetHSM production container registry and adds a note about the login requirement for the registry.