### PR TITLE
Update linkcheck dependencies and fix broken hyperlinks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==1.0.0
 Babel==2.16.0
 beautifulsoup4==4.12.3
-certifi==2024.8.30
+certifi==2026.7.22
 charset-normalizer==3.4.0
 docutils==0.21.2
 furo==2024.8.6
@@ -31,4 +31,4 @@ urllib3==2.2.3
 setuptools==75.6.0
 docutils==0.21.2
 sphinx-design==0.6.1
-LinkChecker==10.5.0
+LinkChecker==10.6.0

--- a/source/components/nextbox/remote/ipv6-settings.rst
+++ b/source/components/nextbox/remote/ipv6-settings.rst
@@ -36,6 +36,6 @@ instead of the default, which is the 1st radio button.
 
 
 
-.. _IPv6 Test: https://ready.chair6.net/
+.. _IPv6 Test: https://dnschecker.org/ipv6-compatibility-checker.php
 
 

--- a/source/components/software/nk-app2/installation-linux.rst
+++ b/source/components/software/nk-app2/installation-linux.rst
@@ -34,7 +34,7 @@ Manual Installation
 Installation from Source
 ------------------------
 
-To install Nitrokey App 2 from source, you need Python 3.10 or later and `pipx <https://pipx.pypa.io/stable/how-to/install-pipx/>`__.
+To install Nitrokey App 2 from source, you need Python 3.10 or later and `pipx <https://pipx.pypa.io/latest/how-to/install-pipx.html#linux>`__.
 
 1. Execute ``pipx install nitrokeyapp`` to install Nitrokey App 2.
 2. :doc:`Set up the udev rules for nitropy <../nitropy/linux/udev>`


### PR DESCRIPTION
This PR updates the `linkchecker` and the associated `certifi` dependencies. It also fixes two broken hyperlinks.