### PR TITLE
Nethsm fixes

### DIFF
--- a/source/components/nethsm/administration.rst
+++ b/source/components/nethsm/administration.rst
@@ -786,7 +786,7 @@ Restore
 
 The NetHSM can be restored from a backup file.
 
-* If the NetHSM is *Unprovisioned* it will restore all *User Data* including system configuration and reboot. Therefore the system may get different network settings, TLS certificate and *Unlock Passphrase* afterwards. The NetHSM ends in a *Locked* state.
+* If the NetHSM is *Unprovisioned* it will restore all *User Data* including system configuration. After the restore the NetHSM is in a *Locked* state. The restored TLS certificate and *Unlock Passphrase* are immediately available. The network settings are only applied after a reboot.
 * If the NetHSM is *Provisioned* it will restore users and user keys but not system configuration. In this case all previously existing users and user keys will be deleted. The NetHSM ends in an *Operational* state.
 
 The restore can be applied as follows.

--- a/source/components/nethsm/clustering.rst
+++ b/source/components/nethsm/clustering.rst
@@ -161,7 +161,9 @@ This CA now has to be installed on every node.
 To do this, first generate a Certificate Signing Request (CSR) from the node with the ``/config/tls/csr.pem`` endpoint (refer to the `API documentation <https://nethsmdemo.nitrokey.com/api_docs/index.html>`__).
 
 .. note::
-   To properly authenticate nodes, the clustering backend (etcd) expects that each node has a certificate with a properly filled Subject Alt Names (SAN) field. In particular, nodes expected to be reached only via their IP need to have a proper IP SAN in their certificate. IP SANs can be requested for the CSR by prefixing "IP:" to the names, as in ``openssl``:
+   To properly authenticate nodes, the clustering backend (etcd) expects that each node has a certificate with a properly filled Subject Alt Names (SAN) field.
+   Nodes are expected to be reached only via their IP and need to have a proper IP SAN in their certificate.
+   IP SANs can be requested for the CSR by prefixing "IP:" to the names, as in ``openssl``:
 
    .. code-block:: text
 

--- a/source/components/nethsm/clustering.rst
+++ b/source/components/nethsm/clustering.rst
@@ -169,6 +169,9 @@ To do this, first generate a Certificate Signing Request (CSR) from the node wit
 
       "subjectAltNames": [ "normalname.org", "IP:192.168.1.1" ]
 
+   If you want to use a public CA for signing your certificates your nodes must use public IP addresses.
+   This is due to a security requirement which forbids a public CA to issue certificates with a private IP address in the IP SAN.
+
 Given the obtained CSR (let's call it ``nethsm.csr``), we can then generate a certificate for it, ready to be installed. For example with ``openssl``:
 
 .. code-block:: bash

--- a/source/components/nethsm/system_recovery.rst
+++ b/source/components/nethsm/system_recovery.rst
@@ -36,12 +36,14 @@ The system recovery can be performed as follows.
       3. Write the installer image to a USB flash drive.
          For this you could use the graphical tool `balenaEtcher <https://etcher.balena.io/>`__. On Linux you could also use the command line tool `dd`.
          Ignore any warning that a partition table is missing.
-      4. Connect the USB flash drive with any USB port of the NetHSM.
+      4. Connect the USB flash drive to a USB port on the NetHSM.
+         NetHSM can boot from the USB ports on the front of the machine and the four vertical stacked ones on the back of the machine.
 
          .. note::
             Some USB drives are incompatible with the NetHSM.
             This results in the NetHSM not recognizing them as a boot media.
             In case the NetHSM does not boot from the connected USB drive, try a different USB drive model.
+            Best results are achieved with drives that have samller capacities and USB 2.0 interface.
 
       5. Optionally: Connect a keyboard and monitor with the NetHSM.
       6. Make sure the system is turned off, but connected to power.


### PR DESCRIPTION
This PR makes changes based on customer feedback for NetHSM.

- Be more detailed about the restore process. Especially, that a manual reboot is required for network settings to apply.
- Define the USB ports for booting a NetHSM 2 from a USB drive.
- Make clear that cluster nodes are only added by IP address.
- Add constrain for cluster certificates from public CAs.